### PR TITLE
Feature/#72/트림 레포지토리 계층 기능 구현

### DIFF
--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/TrimEntity.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/TrimEntity.java
@@ -1,0 +1,13 @@
+package com.h2o.h2oServer.domain.trim;
+
+import lombok.*;
+
+
+@Data
+@Builder
+public class TrimEntity {
+    private Long id;
+    private String name;
+    private String description;
+    private Integer price;
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapper.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapper.java
@@ -1,0 +1,17 @@
+package com.h2o.h2oServer.domain.trim.mapper;
+
+import com.h2o.h2oServer.domain.trim.TrimEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface TrimMapper {
+    TrimEntity findById(Long id);
+
+    List<TrimEntity> findByCarId(Long id);
+
+    List<TrimEntity> findAll();
+
+    List<String> showTables();
+}

--- a/backend/src/main/resources/static/mapper/trim/TrimMapper.xml
+++ b/backend/src/main/resources/static/mapper/trim/TrimMapper.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.h2o.h2oServer.domain.trim.mapper.TrimMapper">
+    <select id="findById" resultType="TrimEntity">
+        select id, name, description, price
+        from trims
+        where id = #{id}
+    </select>
+
+    <select id="findByCarId" resultType="TrimEntity">
+        select id, name, description, price
+        from trims
+        where car_id = #{id}
+    </select>
+
+    <select id="showTables" resultType="string">
+        SHOW TABLES
+    </select>
+
+    <select id="findAll" resultType="TrimEntity">
+        select id, name, description, price
+        from trims
+    </select>
+</mapper>

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
@@ -1,0 +1,120 @@
+package com.h2o.h2oServer.domain.trim.mapper;
+
+import com.h2o.h2oServer.domain.trim.TrimEntity;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.*;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@MybatisTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Sql("classpath:db/trims-data.sql")
+class TrimMapperTest {
+
+    @Autowired
+    private TrimMapper trimMapper;
+
+    private SoftAssertions softly;
+
+    @BeforeEach
+    void setup() {
+        softly = new SoftAssertions();
+    }
+
+    @Test
+    @DisplayName("존재하는 회원에 대해서, 해당하는 row를 Trim 객체에 담아 반환한다.")
+    @Order(1)
+    void findById() {
+        //given
+        Long targetId = 1L;
+        TrimEntity expectedTrimEntity = TrimEntity.builder()
+                .id(targetId)
+                .name("Trim 1")
+                .description("Basic Trim")
+                .price(1500)
+                .build();
+
+        //when
+        TrimEntity actualTrimEntity = trimMapper.findById(targetId);
+
+        //then
+        softly.assertThat(actualTrimEntity).as("유효한 데이터가 매핑되었는지 확인").isNotNull();
+        softly.assertThat(actualTrimEntity).as("데이터베이스에 존재하는 데이터인지 확인").isEqualTo(expectedTrimEntity);
+        softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원에 대해서는 null을 반환한다.")
+    void findByIdWithoutResult() {
+        //given
+        Long targetId = Long.MAX_VALUE;
+
+        //when
+        TrimEntity actualTrimEntity = trimMapper.findById(targetId);
+
+        //then
+        assertThat(actualTrimEntity).isNull();
+    }
+
+    @Test
+    @DisplayName("존재하는 회원에 대해서, 해당하는 row를 Trim 객체에 담아 반환한다.")
+    @Order(2)
+    void findByCarId() {
+        //given
+        Long targetCarId = 1L;
+        TrimEntity expectedTrimEntity1 = TrimEntity.builder()
+                .id(11L)
+                .name("Trim 1")
+                .description("Basic Trim")
+                .price(1500)
+                .build();
+        TrimEntity expectedTrimEntity2 = TrimEntity.builder()
+                .id(12L)
+                .name("Trim 2")
+                .description("Advanced Trim")
+                .price(2500)
+                .build();
+
+        //when
+        List<TrimEntity> actualTrimEntities = trimMapper.findByCarId(targetCarId);
+
+        //then
+        softly.assertThat(actualTrimEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
+        softly.assertThat(actualTrimEntities).as("유효한 데이터만 매핑되었는지 확인").hasSize(2);
+        softly.assertThat(actualTrimEntities).as("CarId에 해당하는 trim 객체가 모두 매핑되었는지 확인")
+                .contains(expectedTrimEntity1)
+                .contains(expectedTrimEntity2);
+        softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원에 대해서는 null을 반환한다.")
+    void findByCarIdWithoutResult() {
+        //given
+        Long targetCarId = Long.MAX_VALUE;
+
+        //when
+        List<TrimEntity> actualTrimEntities = trimMapper.findByCarId(targetCarId);
+
+        //then
+        assertThat(actualTrimEntities).isEmpty();
+    }
+
+    @Test
+    @DisplayName("데이터베이스 상의 모든 row를 가져온다.")
+    void findAll() {
+        //given
+        Long expectedLength = 10L;
+
+        //when
+        List<TrimEntity> actualTrimEntities = trimMapper.findAll();
+
+        //then
+        assertThat(actualTrimEntities).as("db에 존재하는 row의 개수와 길이가 같은지 확인").hasSize(Math.toIntExact(expectedLength));
+    }
+}


### PR DESCRIPTION
# :eyes: What is this PR?
trims 테이블 데이터 접근 관련 기능 구현
# :pencil: Changes
- TrimMapper 테스트 코드 구현
- TrimMapper.xml, 클래스 코드 구현
- db table과 매핑하기 위한 TrimEntity 클래스 구현

## ❓ 피드백 필요/논의사항
- 테스트 코드에서 실행되는 DDL에서 FK 제약조건을 없앴다. 각각의 단위테스트 실행 후에 롤백되는 과정에서 FK 제약조건 때문에 데이터가 제대로 지워지지 않는 오류를 삭제하기 위함이다. 
- 요구사항 특성상 서버 애플리케이션이 insert나 delete, update를 하지 않기 때문에 테스트에 쓰일 데이터를 DML로 지정한다. 이것 때문에 각 단위 테스트 메서드마다 해당 쿼리가 반복적으로 실행되면서 PK 값이 계속 바뀌게 되는데, 이 문제를 해결하기 위해서 테스트 메서드의 실행 순서를 지정했다. 
- Trim 정보 반환 API와 관련된 도메인이 매우 많아서, 도메인 별로 테스크를 쪼개는 것이 어떨까 싶다... 아니면 테이블 단위로 Mapper를 쪼개지 않고, Mapper에서 조인 여러 번 해서 원하는 형태에 가깝게 만드는 방법도 있다. 어느 쪽이 좋을지... 
## :pushpin: Related issue(s)
#72 
