### PR TITLE
feature/#77/내장 색상 정보 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/api/TrimController.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/api/TrimController.java
@@ -2,8 +2,8 @@ package com.h2o.h2oServer.domain.trim.api;
 
 import com.h2o.h2oServer.domain.trim.application.TrimService;
 import com.h2o.h2oServer.domain.trim.dto.ExternalColorDto;
+import com.h2o.h2oServer.domain.trim.dto.InternalColorDto;
 import com.h2o.h2oServer.domain.trim.dto.TrimDto;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,5 +25,10 @@ public class TrimController {
     @GetMapping("trim/{trimId}/external-color")
     public List<ExternalColorDto> getExternalColorInformation(@PathVariable Long trimId) {
         return trimService.findExternalColorInformation(trimId);
+    }
+
+    @GetMapping("/trim/{trimId}/internal-color")
+    public List<InternalColorDto> getInternalColorInformation(@PathVariable Long trimId) {
+        return trimService.findInternalColorInformation(trimId);
     }
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/application/TrimService.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/application/TrimService.java
@@ -1,9 +1,11 @@
 package com.h2o.h2oServer.domain.trim.application;
 
+import com.h2o.h2oServer.domain.trim.dto.InternalColorDto;
 import com.h2o.h2oServer.domain.trim.dto.ExternalColorDto;
 import com.h2o.h2oServer.domain.trim.dto.TrimDto;
 import com.h2o.h2oServer.domain.trim.entity.ExternalColorEntity;
 import com.h2o.h2oServer.domain.trim.entity.ImageEntity;
+import com.h2o.h2oServer.domain.trim.entity.InternalColorEntity;
 import com.h2o.h2oServer.domain.trim.entity.OptionStatisticsEntity;
 import com.h2o.h2oServer.domain.trim.entity.TrimEntity;
 import com.h2o.h2oServer.domain.trim.mapper.ExternalColorMapper;
@@ -53,5 +55,13 @@ public class TrimService {
         List<ImageEntity> imageEntities = externalColorMapper.findImages(externalColorEntityId);
 
         return ExternalColorDto.of(externalColorEntity, imageEntities);
+    }
+
+    public List<InternalColorDto> findInternalColorInformation(Long trimId) {
+        List<InternalColorEntity> internalColorEntities = trimMapper.findInternalColor(trimId);
+
+        return internalColorEntities.stream()
+                .map(InternalColorDto::of)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/InternalColorDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/InternalColorDto.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 public class InternalColorDto {
     private Long id;
     private String name;
-    private Float choiceRatio;
+    private Integer choiceRatio;
     private Integer price;
     private String fabricImage;
     private String bannerImage;
@@ -19,7 +19,7 @@ public class InternalColorDto {
         return InternalColorDto.builder()
                 .id(internalColorEntity.getId())
                 .name(internalColorEntity.getName())
-                .choiceRatio(internalColorEntity.getChoiceRatio())
+                .choiceRatio(Math.round(internalColorEntity.getChoiceRatio() * 100))
                 .price(internalColorEntity.getPrice())
                 .fabricImage(internalColorEntity.getFabricImage())
                 .bannerImage(internalColorEntity.getInternalImage())

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/InternalColorDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/InternalColorDto.java
@@ -1,0 +1,28 @@
+package com.h2o.h2oServer.domain.trim.dto;
+
+
+import com.h2o.h2oServer.domain.trim.entity.InternalColorEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class InternalColorDto {
+    private Long id;
+    private String name;
+    private Float choiceRatio;
+    private Integer price;
+    private String fabricImage;
+    private String bannerImage;
+
+    public static InternalColorDto of(InternalColorEntity internalColorEntity) {
+        return InternalColorDto.builder()
+                .id(internalColorEntity.getId())
+                .name(internalColorEntity.getName())
+                .choiceRatio(internalColorEntity.getChoiceRatio())
+                .price(internalColorEntity.getPrice())
+                .fabricImage(internalColorEntity.getFabricImage())
+                .bannerImage(internalColorEntity.getInternalImage())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/entity/InternalColorEntity.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/entity/InternalColorEntity.java
@@ -1,0 +1,15 @@
+package com.h2o.h2oServer.domain.trim.entity;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class InternalColorEntity {
+    private Long id;
+    private String name;
+    private String fabricImage;
+    private String internalImage;
+    private Integer price;
+    private Float choiceRatio;
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapper.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapper.java
@@ -1,9 +1,6 @@
 package com.h2o.h2oServer.domain.trim.mapper;
 
-import com.h2o.h2oServer.domain.trim.entity.ExternalColorEntity;
-import com.h2o.h2oServer.domain.trim.entity.ImageEntity;
-import com.h2o.h2oServer.domain.trim.entity.OptionStatisticsEntity;
-import com.h2o.h2oServer.domain.trim.entity.TrimEntity;
+import com.h2o.h2oServer.domain.trim.entity.*;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -21,6 +18,8 @@ public interface TrimMapper {
     List<ImageEntity> findImages(Long id);
 
     List<OptionStatisticsEntity> findOptionStatistics(Long id);
+
+    List<InternalColorEntity> findInternalColor(Long id);
 
     List<ExternalColorEntity> findExternalColor(Long id);
 }

--- a/backend/src/main/resources/static/mapper/trim/TrimMapper.xml
+++ b/backend/src/main/resources/static/mapper/trim/TrimMapper.xml
@@ -48,4 +48,12 @@
         where trim_id = #{id}
         order by choice_ratio desc
     </select>
+
+    <select id="findInternalColor" resultType="InternalColorEntity">
+        select id, name, fabric_image, internal_image, price, choice_ratio
+        from internal_color
+                 join trims_internal_color on internal_color.id = trims_internal_color.internal_color_id
+        where trim_id = #{id}
+            order by choice_ratio desc, name desc
+    </select>
 </mapper>

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/application/TrimServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/application/TrimServiceTest.java
@@ -1,6 +1,7 @@
 package com.h2o.h2oServer.domain.trim.application;
 
 import com.h2o.h2oServer.domain.trim.dto.ExternalColorDto;
+import com.h2o.h2oServer.domain.trim.dto.InternalColorDto;
 import com.h2o.h2oServer.domain.trim.dto.TrimDto;
 import com.h2o.h2oServer.domain.trim.entity.ExternalColorEntity;
 import com.h2o.h2oServer.domain.trim.entity.ImageEntity;
@@ -8,6 +9,7 @@ import com.h2o.h2oServer.domain.trim.entity.OptionStatisticsEntity;
 import com.h2o.h2oServer.domain.trim.entity.TrimEntity;
 import com.h2o.h2oServer.domain.trim.mapper.ExternalColorMapper;
 import com.h2o.h2oServer.domain.trim.mapper.TrimMapper;
+import com.h2o.h2oServer.domain.trim.entity.InternalColorEntity;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
@@ -69,7 +71,7 @@ class TrimServiceTest {
         //when
         List<TrimDto> actualTrimDtos = trimService.findTrimInformation(vehicleId);
 
-        //then
+        //thenㅊ
         softly.assertThat(actualTrimDtos).as("null이 아니다.").isNotNull();
         softly.assertThat(actualTrimDtos).as("TrimDto를 포함한다.").isEmpty();
         softly.assertAll();
@@ -170,6 +172,48 @@ class TrimServiceTest {
                         .name("Trim B")
                         .description("Description of Trim b")
                         .price(70000)
+                        .build()
+        );
+    }
+
+    @Test
+    @DisplayName("trimId에 해당하는 internalColor를 Dto로 포매팅해서 반환한다.")
+    void findInternalColorInformation() {
+        //given
+        Long trimId = 1L;
+        when(trimMapper.findInternalColor(trimId)).thenReturn(generateInernalColorEntityList());
+
+        //when
+        List<InternalColorDto> actualInternalColorDtos = trimService.findInternalColorInformation(trimId);
+
+        //then
+        softly.assertThat(actualInternalColorDtos).as("null이 아니다.")
+                .isNotNull();
+        softly.assertThat(actualInternalColorDtos).as("입력받은 entity의 개수만큼 dto를 담고 있다.")
+                .hasSize(2);
+        softly.assertThat(actualInternalColorDtos.get(0).getName()).as("입력받은 entity의 정보를 가지고 있다.")
+                .isEqualTo("Red");
+        softly.assertThat(actualInternalColorDtos.get(1).getName()).as("입력받은 entity의 정보를 가지고 있다.")
+                .isEqualTo("Blue");
+    }
+
+    private List<InternalColorEntity> generateInernalColorEntityList() {
+        return List.of(
+                InternalColorEntity.builder()
+                        .id(1L)
+                        .choiceRatio(0.3f)
+                        .price(2000)
+                        .fabricImage("fabric_image_url_1")
+                        .internalImage("internal_image_url_1")
+                        .name("Red")
+                        .build(),
+                InternalColorEntity.builder()
+                        .id(2L)
+                        .choiceRatio(0.2f)
+                        .price(1500)
+                        .fabricImage("fabric_image_url_2")
+                        .internalImage("internal_image_url_2")
+                        .name("Blue")
                         .build()
         );
     }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
@@ -1,6 +1,7 @@
 package com.h2o.h2oServer.domain.trim.mapper;
 
 import com.h2o.h2oServer.domain.trim.entity.ExternalColorEntity;
+import com.h2o.h2oServer.domain.trim.entity.InternalColorEntity;
 import com.h2o.h2oServer.domain.trim.entity.TrimEntity;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.*;
@@ -151,6 +152,41 @@ class TrimMapperTest {
         softly.assertThat(actualExternalColorEntities).as("trimId에 해당하는 externalColorEntity 객체가 모두 매핑되었는지 확인")
                 .contains(expectedExternalColorEntity1)
                 .contains(expectedExternalColorEntity2);
+        softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("존재하는 trimId에 대한 내부 색상 요청에 대해서 InternalColorEntity List를 반환한다. ")
+    @Sql("classpath:db/internal-color-data.sql")
+    void findInternalColor() {
+        //given
+        Long trimId = 1L;
+        InternalColorEntity expectEntity1 = InternalColorEntity.builder()
+                .id(1L)
+                .choiceRatio(0.3f)
+                .price(2000)
+                .fabricImage("fabric_image_url_1")
+                .internalImage("internal_image_url_1")
+                .name("Red")
+                .build();
+        InternalColorEntity expectEntity2 = InternalColorEntity.builder()
+                .id(2L)
+                .choiceRatio(0.2f)
+                .price(1500)
+                .fabricImage("fabric_image_url_2")
+                .internalImage("internal_image_url_2")
+                .name("Blue")
+                .build();
+
+        //when
+        List<InternalColorEntity> actualEntities = trimMapper.findInternalColor(trimId);
+
+        //then
+        softly.assertThat(actualEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
+        softly.assertThat(actualEntities).as("유효한 데이터만 매핑되었는지 확인").hasSize(2);
+        softly.assertThat(actualEntities).as("trimId에 해당하는 InternalColorEntity 객체가 모두 매핑되었는지 확인")
+                .contains(expectEntity1)
+                .contains(expectEntity2);
         softly.assertAll();
     }
 }

--- a/backend/src/test/resources/db/internal-color-data.sql
+++ b/backend/src/test/resources/db/internal-color-data.sql
@@ -1,0 +1,11 @@
+INSERT INTO internal_color (name, fabric_image, internal_image) VALUES
+    ('Red', 'fabric_image_url_1', 'internal_image_url_1'),
+    ('Blue', 'fabric_image_url_2', 'internal_image_url_2'),
+    ('Green', 'fabric_image_url_3', 'internal_image_url_3');
+
+INSERT INTO trims_internal_color (trim_id, internal_color_id, price, choice_ratio) VALUES
+    (1, 1, 2000, 0.3),
+    (1, 2, 1500, 0.2),
+    (2, 1, 1800, 0.5),
+    (2, 3, 1600, 0.4),
+    (3, 2, 2200, 0.6);


### PR DESCRIPTION
# :eyes: What is this PR?
내장 색상 정보 조회 기능, API 구현
# :pencil: Changes
- 트림 내부 색상 정보 반환을 위한 쿼리와 Mapper interface, Mapper 테스트 코드를 작성했다.
- Mapper단 테스트를 위한 sql 스크립트를 작성했다.
- 내부 색상 사진 정보 반환을 위한 쿼리와 테스트 코드를 작성했다.
- entity to dto 로직의 테스트 코드와 service를 구현했다.
- controller를 구현했다.

## :pushpin: Related issue(s)
closes #77 
## :camera: Attachment(optional)
<img width="1392" alt="스크린샷 2023-08-12 오후 9 07 59" src="https://github.com/softeerbootcamp-2nd/H2-O/assets/91039622/35a57b9d-de92-4251-9da5-56fda441c389">
