### PR TITLE
Feature/#81/옵션 세부 사항 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/api/OptionController.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/api/OptionController.java
@@ -1,0 +1,20 @@
+package com.h2o.h2oServer.domain.option.api;
+
+import com.h2o.h2oServer.domain.option.application.OptionService;
+import com.h2o.h2oServer.domain.option.dto.OptionDetailsDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OptionController {
+    private final OptionService optionService;
+
+    @GetMapping("/trim/{trimId}/option/{optionId}")
+    public OptionDetailsDto getOptionInformation(@PathVariable Long trimId, @PathVariable Long optionId) {
+        OptionDetailsDto optionInformation = optionService.findOptionInformation(optionId, trimId);
+        return optionInformation;
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/application/OptionService.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/application/OptionService.java
@@ -1,0 +1,24 @@
+package com.h2o.h2oServer.domain.option.application;
+
+import com.h2o.h2oServer.domain.option.dto.OptionDetailsDto;
+import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
+import com.h2o.h2oServer.domain.option.entity.OptionEntity;
+import com.h2o.h2oServer.domain.option.mapper.OptionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OptionService {
+
+    private final OptionMapper optionMapper;
+
+    public OptionDetailsDto findOptionInformation(Long optionId, Long trimId) {
+        OptionEntity optionEntity = optionMapper.findOption(optionId, trimId);
+        List<HashTagEntity> hashTagEntities = optionMapper.findHashTag(optionId);
+
+        return OptionDetailsDto.of(optionEntity, hashTagEntities);
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionDetailsDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionDetailsDto.java
@@ -1,0 +1,34 @@
+package com.h2o.h2oServer.domain.option.dto;
+
+import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
+import com.h2o.h2oServer.domain.option.entity.OptionEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+public class OptionDetailsDto {
+    private String name;
+    private String category;
+    private List<String> hashTags;
+    private String image;
+    private String description;
+    private OptionStatisticsDto hmgData;
+
+    public static OptionDetailsDto of(OptionEntity optionEntity, List<HashTagEntity> hashTagEntities) {
+        return OptionDetailsDto.builder()
+                .name(optionEntity.getName())
+                .category(optionEntity.getCategory().getLabel())
+                .hashTags(hashTagEntities.stream()
+                        .map(hashTagEntity -> hashTagEntity.getName().getLabel())
+                        .collect(Collectors.toList()))
+                .image(optionEntity.getImage())
+                .description(optionEntity.getDescription())
+                .hmgData(OptionStatisticsDto.of(optionEntity.getChoiceRatio(),
+                        optionEntity.getUseCount()))
+                .build();
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionDetailsDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionDetailsDto.java
@@ -17,6 +17,8 @@ public class OptionDetailsDto {
     private String image;
     private String description;
     private OptionStatisticsDto hmgData;
+    private Integer price;
+    private boolean containsHmgData;
 
     public static OptionDetailsDto of(OptionEntity optionEntity, List<HashTagEntity> hashTagEntities) {
         return OptionDetailsDto.builder()
@@ -29,6 +31,12 @@ public class OptionDetailsDto {
                 .description(optionEntity.getDescription())
                 .hmgData(OptionStatisticsDto.of(optionEntity.getChoiceRatio(),
                         optionEntity.getUseCount()))
+                .price(optionEntity.getPrice())
+                .containsHmgData(containsHmgData(optionEntity))
                 .build();
+    }
+
+    private static boolean containsHmgData(OptionEntity optionEntity) {
+        return optionEntity.getChoiceRatio() != null;
     }
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionStatisticsDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionStatisticsDto.java
@@ -1,0 +1,21 @@
+package com.h2o.h2oServer.domain.option.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class OptionStatisticsDto {
+    private static final int SELL_NUMBER = 3509;
+    private boolean isOverHalf;
+    private Integer choiceCount;
+    private Float useCount;
+
+    public static OptionStatisticsDto of(Float choiceRatio, Float useCount) {
+        return OptionStatisticsDto.builder()
+                .isOverHalf(choiceRatio > 0.5)
+                .useCount(useCount)
+                .choiceCount(Math.round(choiceRatio * SELL_NUMBER))
+                .build();
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionStatisticsDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionStatisticsDto.java
@@ -1,10 +1,12 @@
 package com.h2o.h2oServer.domain.option.dto;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode
 public class OptionStatisticsDto {
     private static final int SELL_NUMBER = 3509;
     private boolean isOverHalf;

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/entity/HashTagEntity.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/entity/HashTagEntity.java
@@ -1,0 +1,11 @@
+package com.h2o.h2oServer.domain.option.entity;
+
+import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class HashTagEntity {
+    private HashTag name;
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/entity/OptionEntity.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/entity/OptionEntity.java
@@ -1,0 +1,16 @@
+package com.h2o.h2oServer.domain.option.entity;
+
+import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OptionEntity {
+    private String name;
+    private String image;
+    private String description;
+    private OptionCategory category;
+    private Float useCount;
+    private Float choiceRatio;
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/entity/OptionEntity.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/entity/OptionEntity.java
@@ -13,4 +13,6 @@ public class OptionEntity {
     private OptionCategory category;
     private Float useCount;
     private Float choiceRatio;
+    private Integer price;
+    private String optionType;
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/entity/enums/HashTag.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/entity/enums/HashTag.java
@@ -1,0 +1,52 @@
+package com.h2o.h2oServer.domain.option.entity.enums;
+
+public enum HashTag {
+    LEISURE("레저"),
+    SPORTS("스포츠"),
+    MOVIE("영화감상"),
+    CAMPING("캠핑"),
+    STYLE("스타일"),
+    SMART("스마트"),
+    COMFORTABLE("쾌적"),
+    LONG_DISTANCE_DRIVING("장거리 운전"),
+    SHORT_DISTANCE_DRIVING("단거리 운전"),
+    CHILD_COMMUTE("자녀 통학"),
+    COMMUTE("출퇴근"),
+    BUSINESS_TRIP("출장"),
+    SAFETY("안전"),
+    PARKING("주차/출차"),
+    CHILDREN("자녀"),
+    SINGLE_HOUSEHOLD("1인가구"),
+    COUPLE("부부"),
+    MULTI_PERSON_FAMILY("다인가족"),
+    EYE_CATCHER("눈길"),
+    CLOUDY_DAY("흐린날"),
+    BEGINNER_DRIVING("초보운전"),
+    HIGHWAY("고속도로"),
+    NATIONAL_ROAD("국도"),
+    NIGHT("야간"),
+    URBAN("도시"),
+    RURAL("시외"),
+    FEMALE("여성"),
+    MALE("남성"),
+    PET("반려견/묘");
+
+    private final String label;
+
+    HashTag(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public static HashTag fromLabel(String label) {
+        for (HashTag hashTag : HashTag.values()) {
+            if (hashTag.getLabel().equals(label)) {
+                return hashTag;
+            }
+        }
+        throw new IllegalArgumentException("존재하지 않는 해시태그 라벨 : " + label);
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/entity/enums/OptionCategory.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/entity/enums/OptionCategory.java
@@ -1,0 +1,34 @@
+package com.h2o.h2oServer.domain.option.entity.enums;
+
+public enum OptionCategory {
+    DETAILED_ITEM("상세품목"),
+    ACCESSORY("악세사리"),
+    WHEEL("휠"),
+    POWERTRAIN_PERFORMANCE("파워트레인/성능"),
+    INTELLIGENT_SAFETY_TECH("지능형 안전기술"),
+    SAFETY("안전"),
+    INTERIOR("내장"),
+    EXTERIOR("외관"),
+    SEATS("시트"),
+    CONVENIENCE("편의"),
+    MULTIMEDIA("멀티미디어");
+
+    private final String label;
+
+    OptionCategory(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public static OptionCategory fromLabel(String label) {
+        for (OptionCategory optionCategory : OptionCategory.values()) {
+            if (optionCategory.getLabel().equals(label)) {
+                return optionCategory;
+            }
+        }
+        throw new IllegalArgumentException("존재하지 않는 옵션 라벨 : " + label);
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/mapper/OptionMapper.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/mapper/OptionMapper.java
@@ -1,0 +1,12 @@
+package com.h2o.h2oServer.domain.option.mapper;
+
+import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
+import com.h2o.h2oServer.domain.option.entity.OptionEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface OptionMapper {
+    OptionEntity findOption(Long optionId, Long trimId);
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/mapper/OptionMapper.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/mapper/OptionMapper.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Mapper
 public interface OptionMapper {
     OptionEntity findOption(Long optionId, Long trimId);
+    List<HashTagEntity> findHashTag(Long optionId);
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/TrimDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/TrimDto.java
@@ -17,7 +17,7 @@ public class TrimDto {
     private String description;
     private Integer price;
     private List<String> images;
-    private List<OptionStatisticsDto> options;
+    private List<TrimStatisticsDto> options;
 
     public static TrimDto of(TrimEntity trimEntity,
                      List<ImageEntity> imageEntities,
@@ -30,7 +30,7 @@ public class TrimDto {
                 .images(imageEntities.stream()
                         .map(ImageEntity::getImage)
                         .collect(Collectors.toList()))
-                .options(OptionStatisticsDto.ListOf(optionStatisticsEntities))
+                .options(TrimStatisticsDto.ListOf(optionStatisticsEntities))
                 .build();
     }
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/TrimStatisticsDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/TrimStatisticsDto.java
@@ -9,20 +9,20 @@ import java.util.stream.Collectors;
 
 @Builder
 @Getter
-public class OptionStatisticsDto {
+public class TrimStatisticsDto {
     private String dataLabel;
     private Float frequency;
 
-    public static OptionStatisticsDto of(OptionStatisticsEntity entity) {
-        return OptionStatisticsDto.builder()
+    public static TrimStatisticsDto of(OptionStatisticsEntity entity) {
+        return TrimStatisticsDto.builder()
                 .dataLabel(entity.getName())
                 .frequency(entity.getUseCount())
                 .build();
     }
 
-    public static List<OptionStatisticsDto> ListOf(List<OptionStatisticsEntity> entities) {
+    public static List<TrimStatisticsDto> ListOf(List<OptionStatisticsEntity> entities) {
         return entities.stream()
-                .map(OptionStatisticsDto::of)
+                .map(TrimStatisticsDto::of)
                 .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/h2o/h2oServer/global/typeHandler/HashTagTypeHandler.java
+++ b/backend/src/main/java/com/h2o/h2oServer/global/typeHandler/HashTagTypeHandler.java
@@ -1,0 +1,38 @@
+package com.h2o.h2oServer.global.typeHandler;
+
+import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+import org.apache.ibatis.type.TypeHandler;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@MappedTypes(HashTag.class)
+public class HashTagTypeHandler implements TypeHandler<HashTag> {
+
+    @Override
+    public void setParameter(PreparedStatement ps, int i, HashTag parameter, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, parameter.getLabel());
+    }
+
+    @Override
+    public HashTag getResult(ResultSet rs, String columnName) throws SQLException {
+        String label = rs.getString(columnName);
+        return HashTag.fromLabel(label);
+    }
+
+    @Override
+    public HashTag getResult(ResultSet rs, int columnIndex) throws SQLException {
+        String label = rs.getString(columnIndex);
+        return HashTag.fromLabel(label);
+    }
+
+    @Override
+    public HashTag getResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String label = cs.getString(columnIndex);
+        return HashTag.fromLabel(label);
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/global/typeHandler/OptionCategoryTypeHandler.java
+++ b/backend/src/main/java/com/h2o/h2oServer/global/typeHandler/OptionCategoryTypeHandler.java
@@ -1,0 +1,38 @@
+package com.h2o.h2oServer.global.typeHandler;
+
+import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+import org.apache.ibatis.type.TypeHandler;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@MappedTypes(OptionCategory.class)
+public class OptionCategoryTypeHandler implements TypeHandler<OptionCategory> {
+
+    @Override
+    public void setParameter(PreparedStatement ps, int i, OptionCategory parameter, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, parameter.getLabel());
+    }
+
+    @Override
+    public OptionCategory getResult(ResultSet rs, String columnName) throws SQLException {
+        String label = rs.getString(columnName);
+        return OptionCategory.fromLabel(label);
+    }
+
+    @Override
+    public OptionCategory getResult(ResultSet rs, int columnIndex) throws SQLException {
+        String label = rs.getString(columnIndex);
+        return OptionCategory.fromLabel(label);
+    }
+
+    @Override
+    public OptionCategory getResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String label = cs.getString(columnIndex);
+        return OptionCategory.fromLabel(label);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -10,6 +10,7 @@ mybatis:
   mapper-locations: static/mapper/**/*.xml
   configuration:
     map-underscore-to-camel-case: true
+  type-handlers-package: com.h2o.h2oServer.global.typeHandler
 
 server:
   port: 8080

--- a/backend/src/main/resources/static/mapper/option/OptionMapper.xml
+++ b/backend/src/main/resources/static/mapper/option/OptionMapper.xml
@@ -3,7 +3,7 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.h2o.h2oServer.domain.option.mapper.OptionMapper">
     <select id="findOption" resultType="OptionEntity">
-        select name, image, description, category, use_count, choice_ratio <!--선택 비율을 선택 개수로 어떻게 바꿀 것인가...-->
+        select name, image, description, category, use_count, choice_ratio, price, option_type <!--선택 비율을 선택 개수로 어떻게 바꿀 것인가...-->
         from options
             join trims_options on trims_options.option_id = options.id
         where trims_options.trim_id = #{trimId} and options.id = #{optionId}

--- a/backend/src/main/resources/static/mapper/option/OptionMapper.xml
+++ b/backend/src/main/resources/static/mapper/option/OptionMapper.xml
@@ -8,4 +8,12 @@
             join trims_options on trims_options.option_id = options.id
         where trims_options.trim_id = #{trimId} and options.id = #{optionId}
     </select>
+
+    <select id="findHashTag" resultType="HashTagEntity">
+        select hashtag.name
+        from options
+                 join options_hashtag on options.id = options_hashtag.option_id
+                 join hashtag on hashtag.id = options_hashtag.hashtag_id
+        where options.id = #{optionId}
+    </select>
 </mapper>

--- a/backend/src/main/resources/static/mapper/option/OptionMapper.xml
+++ b/backend/src/main/resources/static/mapper/option/OptionMapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.h2o.h2oServer.domain.option.mapper.OptionMapper">
+    <select id="findOption" resultType="OptionEntity">
+        select name, image, description, category, use_count, choice_ratio <!--선택 비율을 선택 개수로 어떻게 바꿀 것인가...-->
+        from options
+            join trims_options on trims_options.option_id = options.id
+        where trims_options.trim_id = #{trimId} and options.id = #{optionId}
+    </select>
+</mapper>

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/application/OptionServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/application/OptionServiceTest.java
@@ -1,0 +1,77 @@
+package com.h2o.h2oServer.domain.option.application;
+
+import com.h2o.h2oServer.domain.option.dto.OptionDetailsDto;
+import com.h2o.h2oServer.domain.option.dto.OptionStatisticsDto;
+import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
+import com.h2o.h2oServer.domain.option.entity.OptionEntity;
+import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
+import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
+import com.h2o.h2oServer.domain.option.mapper.OptionMapper;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+class OptionServiceTest {
+    private static OptionMapper optionMapper;
+    private static OptionService optionService;
+    private static SoftAssertions softly;
+
+    @BeforeAll
+    static void beforeAll() {
+        optionMapper = Mockito.mock(OptionMapper.class);
+        optionService = new OptionService(optionMapper);
+        softly = new SoftAssertions();
+    }
+
+    @Test
+    @DisplayName("존재하는 option, trim에 대한 요청인 경우 Dto로 formatting해서 반환한다.")
+    void findOptionInformation() {
+        //given
+        long optionId = 1L;
+        long trimId = 1L;
+        when(optionMapper.findOption(optionId, trimId)).thenReturn(generateOptionEntity());
+        when(optionMapper.findHashTag(optionId)).thenReturn(generateHashTagEntities());
+
+        //when
+        OptionDetailsDto actualOptionDetailsDto = optionService.findOptionInformation(optionId, trimId);
+
+        //then
+        softly.assertThat(actualOptionDetailsDto).as("null이 아니다.").isNotNull();
+        softly.assertThat(actualOptionDetailsDto.getHashTags()).as("세 개의 hashtag 정보를 포함한다.").hasSize(3);
+        softly.assertThat(actualOptionDetailsDto.getName()).as("name = Option 1이다.").isEqualTo("Option 1");
+        softly.assertThat(actualOptionDetailsDto.getCategory()).as("category = 성능/파워트레인").isEqualTo(OptionCategory.POWERTRAIN_PERFORMANCE.getLabel());
+        softly.assertThat(actualOptionDetailsDto.getHmgData()).as("유효한 hmgData를 포함한다.").isEqualTo(OptionStatisticsDto.of(0.3f, 12.5f));
+        softly.assertAll();
+    }
+
+    private static List<HashTagEntity> generateHashTagEntities() {
+        return List.of(
+                HashTagEntity.builder()
+                        .name(HashTag.CAMPING)
+                        .build(),
+                HashTagEntity.builder()
+                        .name(HashTag.LEISURE)
+                        .build(),
+                HashTagEntity.builder()
+                        .name(HashTag.SPORTS)
+                        .build()
+        );
+    }
+
+    private static OptionEntity generateOptionEntity() {
+        return OptionEntity.builder()
+                .name("Option 1")
+                .image("image_url_1")
+                .description("Description for Option 1")
+                .choiceRatio(0.3f)
+                .useCount(12.5f)
+                .category(OptionCategory.POWERTRAIN_PERFORMANCE)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/mapper/OptionMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/mapper/OptionMapperTest.java
@@ -1,6 +1,8 @@
 package com.h2o.h2oServer.domain.option.mapper;
 
+import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
 import com.h2o.h2oServer.domain.option.entity.OptionEntity;
+import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
 import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
@@ -8,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
 
 @MybatisTest
 class OptionMapperTest {
@@ -38,6 +42,35 @@ class OptionMapperTest {
         //then
         softly.assertThat(actualOptionEntity).as("유효한 데이터가 매핑되었는지 확인").isNotNull();
         softly.assertThat(actualOptionEntity).as("데이터베이스에 존재하는 데이터인지 확인").isEqualTo(expectedOptionEntity);
+        softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("존재하는 option에 대해서 유효한 HashTagEntity 객체를 반환한다.")
+    @Sql("classpath:db/hashtag-data.sql")
+    void findHashTag() {
+        //given
+        Long optionId = 1L;
+        List<HashTagEntity> expectedHashTagEntities = List.of(
+                HashTagEntity.builder()
+                        .name(HashTag.CAMPING)
+                        .build(),
+                HashTagEntity.builder()
+                        .name(HashTag.LEISURE)
+                        .build(),
+                HashTagEntity.builder()
+                        .name(HashTag.SPORTS)
+                        .build()
+        );
+        //when
+        List<HashTagEntity> actualHashTagEntities = optionMapper.findHashTag(optionId);
+
+        //then
+        softly.assertThat(actualHashTagEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
+        softly.assertThat(actualHashTagEntities).as("optionId에 해당하는 HashTagEntity 객체가 모두 매핑되었는지 확인")
+                .contains(expectedHashTagEntities.get(0))
+                .contains(expectedHashTagEntities.get(1))
+                .contains(expectedHashTagEntities.get(2));
         softly.assertAll();
     }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/mapper/OptionMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/mapper/OptionMapperTest.java
@@ -34,6 +34,8 @@ class OptionMapperTest {
                 .choiceRatio(0.3f)
                 .useCount(12.5f)
                 .category(OptionCategory.POWERTRAIN_PERFORMANCE)
+                .price(500)
+                .optionType("default")
                 .build();
 
         //when

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/mapper/OptionMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/mapper/OptionMapperTest.java
@@ -1,0 +1,43 @@
+package com.h2o.h2oServer.domain.option.mapper;
+
+import com.h2o.h2oServer.domain.option.entity.OptionEntity;
+import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+@MybatisTest
+class OptionMapperTest {
+
+    @Autowired
+    private OptionMapper optionMapper;
+    private SoftAssertions softly = new SoftAssertions();
+
+    @Test
+    @DisplayName("존재하는 trim, option에 대해서 유효한 OptionEntity 객체를 반환한다.")
+    @Sql("classpath:db/option-data.sql")
+    void findOption() {
+        //given
+        Long trimId = 1L;
+        Long optionId = 1L;
+        OptionEntity expectedOptionEntity = OptionEntity.builder()
+                .name("Option 1")
+                .image("image_url_1")
+                .description("Description for Option 1")
+                .choiceRatio(0.3f)
+                .useCount(12.5f)
+                .category(OptionCategory.POWERTRAIN_PERFORMANCE)
+                .build();
+
+        //when
+        OptionEntity actualOptionEntity = optionMapper.findOption(optionId, trimId);
+
+        //then
+        softly.assertThat(actualOptionEntity).as("유효한 데이터가 매핑되었는지 확인").isNotNull();
+        softly.assertThat(actualOptionEntity).as("데이터베이스에 존재하는 데이터인지 확인").isEqualTo(expectedOptionEntity);
+        softly.assertAll();
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -14,3 +14,5 @@ mybatis:
   mapper-locations: static/mapper/**/*.xml
   configuration:
     map-underscore-to-camel-case: true
+  type-handlers-package: com.h2o.h2oServer.global.typeHandler
+

--- a/backend/src/test/resources/db/hashtag-data.sql
+++ b/backend/src/test/resources/db/hashtag-data.sql
@@ -1,0 +1,25 @@
+-- hashtag 테이블 더미 데이터 생성
+INSERT INTO `hashtag` (`id`, `name`)
+values
+    (1, '캠핑'),
+    (2, '레저'),
+    (3, '스포츠'),
+    (4, '영화감상');
+
+-- options 테이블 더미 데이터 생성
+INSERT INTO `options` (`id`, `name`, `image`, `description`, `use_count`, `category`)
+VALUES
+    (1, 'Option 1', 'image_url_1', 'Description for Option 1', 12.5, '파워트레인/성능'),
+    (2, 'Option 2', 'image_url_2', 'Description for Option 2', 8.3, '파워트레인/성능'),
+    (3, 'Option 3', 'image_url_3', NULL, 5.7, '파워트레인/성능'),
+    (4, 'Option 4', 'image_url_4', 'Description for Option 4', 20.1, '파워트레인/성능');
+
+-- options_hashtag 테이블 더미 데이터 생성
+INSERT INTO `options_hashtag` (`option_id`, `hashtag_id`)
+VALUES
+    (1, 1),
+    (1, 2),
+    (1, 3),
+    (3, 2),
+    (4, 1),
+    (4, 4);

--- a/backend/src/test/resources/db/option-data.sql
+++ b/backend/src/test/resources/db/option-data.sql
@@ -1,0 +1,13 @@
+INSERT INTO `options` (`name`, `image`, `description`, `use_count`, `category`)
+VALUES
+    ('Option 1', 'image_url_1', 'Description for Option 1', 12.5, '파워트레인/성능'),
+    ('Option 2', 'image_url_2', 'Description for Option 2', 8.3, '편의'),
+    ('Option 3', 'image_url_3', NULL, 5.7, '파워트레인/성능'),
+    ('Option 4', 'image_url_4', 'Description for Option 4', 20.1, '편의');
+
+INSERT INTO `trims_options` (`trim_id`, `option_id`, `price`, `option_type`, `choice_ratio`)
+VALUES
+    (1, 1, 500, 'default', 0.3),
+    (1, 2, 700, 'default', 0.2),
+    (2, 3, 300, 'extra', 0.1),
+    (3, 4, 450, 'extra', 0.4);

--- a/backend/src/test/resources/db/schema-ddl.sql
+++ b/backend/src/test/resources/db/schema-ddl.sql
@@ -53,7 +53,8 @@ CREATE TABLE `options`
     `name`        VARCHAR(255) NOT NULL,
     `image`       TEXT         NOT NULL,
     `description` TEXT         NULL,
-    `use_count`   FLOAT        NULL
+    `use_count`   FLOAT        NULL,
+    `category`	  VARCHAR(20)  NOT NULL
 );
 
 CREATE TABLE `powertrain`
@@ -72,9 +73,10 @@ CREATE TABLE `hashtag`
 
 CREATE TABLE `package`
 (
-    `id`    BIGINT PRIMARY KEY AUTO_INCREMENT,
-    `name`  VARCHAR(255) NOT NULL,
-    `image` TEXT         NOT NULL
+    `id`       BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `name`     VARCHAR(255) NOT NULL,
+    `image`    TEXT         NOT NULL,
+    `category` VARCHAR(20)  NOT NULL
 );
 
 CREATE TABLE `quotation`
@@ -89,20 +91,20 @@ CREATE TABLE `quotation`
     `url`               TEXT     NULL
 );
 
-CREATE TABLE `category`
-(
-    `id`   BIGINT PRIMARY KEY AUTO_INCREMENT,
-    `name` VARCHAR(20) NOT NULL
-);
-
-CREATE TABLE `powertrain_spec`
+CREATE TABLE `powertrain_output`
 (
     `powertrain_id`  BIGINT NOT NULL,
-    `output_ps`      FLOAT  NULL,
-    `output_rpm`     INT    NULL,
-    `torque_kgfm`    FLOAT  NULL,
-    `torque_min_rpm` INT    NULL,
-    `torque_max_rpm` INT    NULL
+    `output`         FLOAT  NULL,
+    `min_rpm`        INT    NULL,
+    `max_rpm`        INT    NULL
+);
+
+CREATE TABLE `powertrain_torque`
+(
+    `powertrain_id`  BIGINT NOT NULL,
+    `torque`         FLOAT  NULL,
+    `min_rpm`        INT    NULL,
+    `max_rpm`        INT    NULL
 );
 
 CREATE TABLE `car_powertrain`
@@ -196,12 +198,6 @@ CREATE TABLE `options_quotation`
     `quotation_id` BIGINT NOT NULL
 );
 
-CREATE TABLE `options_category`
-(
-    `option_id`   BIGINT NOT NULL,
-    `category_id` BIGINT NOT NULL
-);
-
 CREATE TABLE `package_options`
 (
     `package_id` BIGINT NOT NULL,
@@ -218,10 +214,4 @@ CREATE TABLE `package_quotation`
 (
     `package_id`   BIGINT NOT NULL,
     `quotation_id` BIGINT NOT NULL
-);
-
-CREATE TABLE `package_category`
-(
-    `package_id`  BIGINT NOT NULL,
-    `category_id` BIGINT NOT NULL
 );


### PR DESCRIPTION
# :eyes: What is this PR?
옵션 세부 사항을 조회하는 기능, API를 구현했다.

# :pencil: Changes
- 옵션 세부 사항 조회 기능, 테스트 코드 구현
- Mapper에서 enum 객체를 바로 매핑받기 위한 TypeHandler 구현

## ❓ 피드백 필요/논의사항
- Service 단 메소드명이 모호한 것 같다. 다른 계층의 메소드들과 그 역할을 구분하기 힘듦
- OptionStatistics의 choiceCount 계산 로직에서 더미 데이터를 이용함. 판매 견적 mock data 추가 이후에 로직 수정 필요
- 선택 비율 데이터가 존재하지 않는 옵션은 null을 응답으로 보낸다. 어떻게 처리할 지 고민 필요
- Enum들, TypeHandler의 구현체에 중복이 너무 많고, 공통적인 특성이 너무 많음. 어떻게 관리하는 것이 좋을지.. 
- OptionCategory enum에서 기본 옵션과 추가 옵션을 구분하지 않는다. 로직 추가 필요

## :pushpin: Related issue(s)
closes #81 
## :camera: Attachment(optional)
<img width="1392" alt="스크린샷 2023-08-14 오전 2 52 06" src="https://github.com/softeerbootcamp-2nd/H2-O/assets/91039622/6bf87768-72ec-4698-91a8-59aa0e8ecfa7">
