### PR TITLE
fix: ExternalColorDto - choiceRatio가 float 형식을 갖는 버그 수정

### DIFF
--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/ExternalColorDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/ExternalColorDto.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 public class ExternalColorDto {
     Long id;
     String name;
-    Float choiceRatio;
+    Integer choiceRatio;
     Integer price;
     String hexCode;
     List<String> images;
@@ -25,7 +25,7 @@ public class ExternalColorDto {
         return ExternalColorDto.builder()
                 .id(externalColorEntity.getId())
                 .name(externalColorEntity.getName())
-                .choiceRatio(externalColorEntity.getChoiceRatio())
+                .choiceRatio(Math.round(externalColorEntity.getChoiceRatio() * 100))
                 .hexCode(externalColorEntity.getColorCode())
                 .price(externalColorEntity.getPrice())
                 .images(imageEntities.stream()


### PR DESCRIPTION
# :eyes: What is this PR?
ExternalColorDto - choiceRatio가 float 형식을 갖는 버그 수정
# :pencil: Changes
- 정수 형태(%)로 반환하도록 수정

## :camera: Attachment(optional)
<img width="1392" alt="스크린샷 2023-08-16 오후 12 08 08" src="https://github.com/softeerbootcamp-2nd/H2-O/assets/91039622/129e365d-ac56-46c8-990f-5a9f38c0dc4f">
