### PR TITLE
fix: 옵션 세부 사항 조회 api 버그 수정

### DIFF
--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionDetailsDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionDetailsDto.java
@@ -21,9 +21,17 @@ public class OptionDetailsDto {
     private OptionStatisticsDto hmgData;
     private Integer price;
     private boolean containsHmgData;
+    private boolean containsUseCount;
 
     public static OptionDetailsDto of(OptionDetailsEntity optionDetailsEntity, List<HashTagEntity> hashTagEntities) {
-        return OptionDetailsDto.builder()
+        OptionDetailsDtoBuilder builder = OptionDetailsDto.builder();
+
+        if (containsHmgData(optionDetailsEntity)) {
+            builder.hmgData(OptionStatisticsDto.of(optionDetailsEntity.getChoiceRatio(),
+                    optionDetailsEntity.getUseCount()));
+        }
+
+        return builder
                 .name(optionDetailsEntity.getName())
                 .category(optionDetailsEntity.getCategory().getLabel())
                 .hashTags(hashTagEntities.stream()
@@ -31,11 +39,14 @@ public class OptionDetailsDto {
                         .collect(Collectors.toList()))
                 .image(optionDetailsEntity.getImage())
                 .description(optionDetailsEntity.getDescription())
-                .hmgData(OptionStatisticsDto.of(optionDetailsEntity.getChoiceRatio(),
-                        optionDetailsEntity.getUseCount()))
                 .price(optionDetailsEntity.getPrice())
                 .containsHmgData(containsHmgData(optionDetailsEntity))
+                .containsUseCount(containsUseCount(optionDetailsEntity))
                 .build();
+    }
+
+    private static boolean containsUseCount(OptionDetailsEntity optionDetailsEntity) {
+        return optionDetailsEntity.getUseCount() != null;
     }
 
     private static boolean containsHmgData(OptionDetailsEntity optionDetailsEntity) {


### PR DESCRIPTION
# :eyes: What is this PR?
일부 옵션에 대해서 세부 사항 조회가 되지 않는 버그를 수정했다. 
# :pencil: Changes
- useCount, choiceRatio의 null값에 대한 처리를 추가했다.  
- API에 useCount 데이터가 존재하는지를 나타내는 필드를 추가했다.
## :pushpin: Related issue(s)
closes #180 
