### PR TITLE
fix: OptionDto - useCount가 항상 null이 되는 오류 수정

### DIFF
--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionDto.java
@@ -29,7 +29,7 @@ public class OptionDto {
             optionDtoBuilder.useCount(Math.round(optionEntity.getUseCount()));
         }
 
-        return OptionDto.builder()
+        return optionDtoBuilder
                 .name(optionEntity.getName())
                 .category(optionEntity.getCategory().getLabel())
                 .hashTags(hashTagEntities.stream()


### PR DESCRIPTION
# :eyes: What is this PR?
OptionDto의 useCount가 항상 null이 되는 오류를 수정했다.

# :pencil: Changes
- OptionDto.of() 메소드에서 builder를 잘못 적용하는 문제를 해결
## :pushpin: Related issue(s)

## :camera: Attachment(optional)
