### PR TITLE
Fix/#189/옵션 세부 정보 응답 형식 수정

### DIFF
--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionStatisticsDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionStatisticsDto.java
@@ -11,11 +11,11 @@ import lombok.Getter;
 @EqualsAndHashCode
 public class OptionStatisticsDto {
     public static final int SELL_NUMBER = 3509;
-    private boolean isOverHalf;
+    private Boolean isOverHalf;
     private Integer choiceCount;
-    private Float useCount;
+    private Integer useCount;
 
-    public static OptionStatisticsDto of(Float choiceRatio, Float useCount) {
+    public static OptionStatisticsDto of(Float choiceRatio, Integer useCount) {
         return OptionStatisticsDto.builder()
                 .isOverHalf(choiceRatio > 0.5)
                 .useCount(useCount)

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/application/OptionServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/application/OptionServiceTest.java
@@ -46,7 +46,7 @@ class OptionServiceTest {
         softly.assertThat(actualOptionDetailsDto.getHashTags()).as("세 개의 hashtag 정보를 포함한다.").hasSize(3);
         softly.assertThat(actualOptionDetailsDto.getName()).as("name = Option 1이다.").isEqualTo("Option 1");
         softly.assertThat(actualOptionDetailsDto.getCategory()).as("category = 성능/파워트레인").isEqualTo(OptionCategory.POWERTRAIN_PERFORMANCE.getLabel());
-        softly.assertThat(actualOptionDetailsDto.getHmgData()).as("유효한 hmgData를 포함한다.").isEqualTo(OptionStatisticsDto.of(0.3f, 12.5f));
+        softly.assertThat(actualOptionDetailsDto.getHmgData()).as("유효한 hmgData를 포함한다.").isEqualTo(OptionStatisticsDto.of(0.3f, 13));
         softly.assertAll();
     }
 


### PR DESCRIPTION
# :eyes: What is this PR?
옵션 세부 정보 API의 응답 형식을 수정했다.
# :pencil: Changes
- `containsHmgData`를 삭제하고 `containsChoiceCount`를 추가했다. `HmgData` 필드는 모두 존재하되, `containsUseCount`가 `true`인 경우 `HmgData.useCount`가 존재하고 `containsChoiceCount`가 true인 경우 `hmgData.choiceCount`, `hmgData.isOverHalf`가 존재한다.

## :pushpin: Related issue(s)
#189 
## :camera: Attachment(optional)
<img width="1392" alt="스크린샷 2023-08-17 오후 12 34 59" src="https://github.com/softeerbootcamp-2nd/H2-O/assets/91039622/bf0178c9-91c0-4e55-973f-1a8fe2a6cfa5">
