### PR TITLE
feature: 견적 완료 페이지 구현1

### DIFF
--- a/iOS/Catalog/Catalog.xcodeproj/project.pbxproj
+++ b/iOS/Catalog/Catalog.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		ED2B8CE52A8CFDF900F561FA /* TrimDefaultOptionDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2B8CE42A8CFDF900F561FA /* TrimDefaultOptionDTO.swift */; };
 		ED2B8CE72A8CFE0C00F561FA /* MaxMinPriceDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2B8CE62A8CFE0C00F561FA /* MaxMinPriceDTO.swift */; };
 		ED2B8CE92A8CFEFA00F561FA /* TrimAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2B8CE82A8CFEFA00F561FA /* TrimAPIManager.swift */; };
+		ED2B8CEC2A8D282F00F561FA /* QuotationCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2B8CEB2A8D282F00F561FA /* QuotationCompleteView.swift */; };
 		ED3DC0282A865B9C009EE04C /* HMGDataCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3DC0272A865B9C009EE04C /* HMGDataCard.swift */; };
 		ED6410922A7FC4FF0033AEBC /* CLButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6410882A7FC4FF0033AEBC /* CLButton.swift */; };
 		ED6410942A7FC4FF0033AEBC /* CLDualChoiceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED64108A2A7FC4FF0033AEBC /* CLDualChoiceButton.swift */; };
@@ -345,6 +346,7 @@
 		ED2B8CE42A8CFDF900F561FA /* TrimDefaultOptionDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimDefaultOptionDTO.swift; sourceTree = "<group>"; };
 		ED2B8CE62A8CFE0C00F561FA /* MaxMinPriceDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaxMinPriceDTO.swift; sourceTree = "<group>"; };
 		ED2B8CE82A8CFEFA00F561FA /* TrimAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimAPIManager.swift; sourceTree = "<group>"; };
+		ED2B8CEB2A8D282F00F561FA /* QuotationCompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotationCompleteView.swift; sourceTree = "<group>"; };
 		ED3DC0272A865B9C009EE04C /* HMGDataCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMGDataCard.swift; sourceTree = "<group>"; };
 		ED6410822A7FC4FF0033AEBC /* DimmedZStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DimmedZStack.swift; sourceTree = "<group>"; };
 		ED6410882A7FC4FF0033AEBC /* CLButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CLButton.swift; sourceTree = "<group>"; };
@@ -466,6 +468,7 @@
 		B155C0AE2A7920A800F540CB /* Catalog */ = {
 			isa = PBXGroup;
 			children = (
+				ED2B8CEA2A8D27C700F561FA /* QuotationComplete */,
 				B1F988DF2A8B1C3700C7B65F /* InteriorColorSelection */,
 				B16DFF482A8A3E2C00642730 /* ExternalColorSelection */,
 				B1604D0E2A8255D200C7B07D /* TrimSelection */,
@@ -907,6 +910,14 @@
 				ED2B8CE02A8CFDBD00F561FA /* TrimDTO.swift */,
 			);
 			path = DTO;
+			sourceTree = "<group>";
+		};
+		ED2B8CEA2A8D27C700F561FA /* QuotationComplete */ = {
+			isa = PBXGroup;
+			children = (
+				ED2B8CEB2A8D282F00F561FA /* QuotationCompleteView.swift */,
+			);
+			path = QuotationComplete;
 			sourceTree = "<group>";
 		};
 		ED6410832A7FC4FF0033AEBC /* Button */ = {
@@ -1377,6 +1388,7 @@
 				EDE434F12A8BFE75007BD0DE /* QuotationIntent.swift in Sources */,
 				B16DFF362A89548300642730 /* ModelTypeRepositoryProtocol.swift in Sources */,
 				B1604D252A8261B400C7B07D /* ContentType.swift in Sources */,
+				ED2B8CEC2A8D282F00F561FA /* QuotationCompleteView.swift in Sources */,
 				B1604D182A82577A00C7B07D /* MockURLProtocol.swift in Sources */,
 				B1604D272A8265B500C7B07D /* RequestManager.swift in Sources */,
 				B1604D292A82660700C7B07D /* APIManagerProtocol.swift in Sources */,

--- a/iOS/Catalog/Catalog.xcodeproj/project.pbxproj
+++ b/iOS/Catalog/Catalog.xcodeproj/project.pbxproj
@@ -180,6 +180,11 @@
 		EDD054002A8C02A900FBD23F /* QuotationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD053FF2A8C02A900FBD23F /* QuotationModel.swift */; };
 		EDD303FD2A8A09E600400DF9 /* HMGTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD303FC2A8A09E600400DF9 /* HMGTag.swift */; };
 		EDD304462A8A6AD300400DF9 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD304452A8A6AD300400DF9 /* API.swift */; };
+		EDD3F0AD2A8DCC94006CE38A /* QuotationCompleteSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD3F0AC2A8DCC94006CE38A /* QuotationCompleteSheet.swift */; };
+		EDD3F0AF2A8DE3BC006CE38A /* CLSheetCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD3F0AE2A8DE3BC006CE38A /* CLSheetCapsule.swift */; };
+		EDD3F0B32A8DF148006CE38A /* DetailQuotationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD3F0B22A8DF148006CE38A /* DetailQuotationList.swift */; };
+		EDD3F0B52A8DF161006CE38A /* DetailQuotationTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD3F0B42A8DF161006CE38A /* DetailQuotationTitle.swift */; };
+		EDD3F0B72A8DFE8D006CE38A /* LeadingTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD3F0B62A8DFE8D006CE38A /* LeadingTitle.swift */; };
 		EDDCA98D2A8D51F1003DFD43 /* QuotationSheetTop.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDCA98C2A8D51F1003DFD43 /* QuotationSheetTop.swift */; };
 		EDDCA98F2A8D553E003DFD43 /* QuotationExteriorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDCA98E2A8D553E003DFD43 /* QuotationExteriorView.swift */; };
 		EDDCA9912A8D5607003DFD43 /* QuotationInteriorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDCA9902A8D5607003DFD43 /* QuotationInteriorView.swift */; };
@@ -397,6 +402,11 @@
 		EDD304372A8A64D600400DF9 /* ModelTypeRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelTypeRepository.swift; sourceTree = "<group>"; };
 		EDD304422A8A668B00400DF9 /* ModelTypeRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTypeRequest.swift; sourceTree = "<group>"; };
 		EDD304452A8A6AD300400DF9 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
+		EDD3F0AC2A8DCC94006CE38A /* QuotationCompleteSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotationCompleteSheet.swift; sourceTree = "<group>"; };
+		EDD3F0AE2A8DE3BC006CE38A /* CLSheetCapsule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLSheetCapsule.swift; sourceTree = "<group>"; };
+		EDD3F0B22A8DF148006CE38A /* DetailQuotationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailQuotationList.swift; sourceTree = "<group>"; };
+		EDD3F0B42A8DF161006CE38A /* DetailQuotationTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailQuotationTitle.swift; sourceTree = "<group>"; };
+		EDD3F0B62A8DFE8D006CE38A /* LeadingTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeadingTitle.swift; sourceTree = "<group>"; };
 		EDDCA98C2A8D51F1003DFD43 /* QuotationSheetTop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotationSheetTop.swift; sourceTree = "<group>"; };
 		EDDCA98E2A8D553E003DFD43 /* QuotationExteriorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotationExteriorView.swift; sourceTree = "<group>"; };
 		EDDCA9902A8D5607003DFD43 /* QuotationInteriorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotationInteriorView.swift; sourceTree = "<group>"; };
@@ -438,6 +448,7 @@
 			children = (
 				B1084BEA2A87DF2B00AE1758 /* BlurredFullScreenCover.swift */,
 				B1084BED2A87E5A800AE1758 /* CLDialog.swift */,
+				EDD3F0AE2A8DE3BC006CE38A /* CLSheetCapsule.swift */,
 			);
 			path = Modal;
 			sourceTree = "<group>";
@@ -922,6 +933,9 @@
 			isa = PBXGroup;
 			children = (
 				ED2B8CEB2A8D282F00F561FA /* QuotationCompleteView.swift */,
+				EDD3F0AC2A8DCC94006CE38A /* QuotationCompleteSheet.swift */,
+				EDD3F0B22A8DF148006CE38A /* DetailQuotationList.swift */,
+				EDD3F0B42A8DF161006CE38A /* DetailQuotationTitle.swift */,
 				EDDCA9902A8D5607003DFD43 /* QuotationInteriorView.swift */,
 				EDDCA98E2A8D553E003DFD43 /* QuotationExteriorView.swift */,
 				EDDCA98C2A8D51F1003DFD43 /* QuotationSheetTop.swift */,
@@ -993,6 +1007,7 @@
 				EDBA5D552A808A8A0050BC35 /* pop-up */,
 				ED6410832A7FC4FF0033AEBC /* Button */,
 				B19436312A7E8C1500C2FD69 /* Alert */,
+				EDD3F0B62A8DFE8D006CE38A /* LeadingTitle.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -1372,6 +1387,8 @@
 				EDBA3E3B2A83E48400BDB00F /* CLCancelButton.swift in Sources */,
 				B1604D6B2A854D3A00C7B07D /* HMGButtonArrowStyle.swift in Sources */,
 				ED1A70982A83646E00F7920F /* (null) in Sources */,
+				EDD3F0B32A8DF148006CE38A /* DetailQuotationList.swift in Sources */,
+				EDD3F0B52A8DF161006CE38A /* DetailQuotationTitle.swift in Sources */,
 				B191DD492A8BE0F4008196CD /* ExteriorColorAPIManager.swift in Sources */,
 				B191DD422A8B8607008196CD /* InteriorColorSelectionModel.swift in Sources */,
 				B191DD2C2A8B4CD6008196CD /* ExternalColorDisplayView.swift in Sources */,
@@ -1392,6 +1409,7 @@
 				B155C0E92A792BB100F540CB /* Color+.swift in Sources */,
 				B1A76B822A88D263009C84EF /* ModelTypeIntent.swift in Sources */,
 				B1604D3A2A8381E900C7B07D /* TrimResponseDTO.swift in Sources */,
+				EDD3F0B72A8DFE8D006CE38A /* LeadingTitle.swift in Sources */,
 				EDC1862F2A893577009EB498 /* CLInactiveButtonStyle.swift in Sources */,
 				B1604D2F2A8335CA00C7B07D /* TrimSelectionRequest.swift in Sources */,
 				B1F988EA2A8B3E5300C7B65F /* InteriorColor.swift in Sources */,
@@ -1440,6 +1458,7 @@
 				EDCF32C42A8A91D500C46A4B /* CLQuotationSummarySheet.swift in Sources */,
 				EDCF32F82A8B90D700C46A4B /* ExternalColorModel.swift in Sources */,
 				B1604D322A836DBE00C7B07D /* Request.swift in Sources */,
+				EDD3F0AD2A8DCC94006CE38A /* QuotationCompleteSheet.swift in Sources */,
 				EDDCA9912A8D5607003DFD43 /* QuotationInteriorView.swift in Sources */,
 				EDF882572A8A708A0077558F /* ModelTypeRequestDTO.swift in Sources */,
 				B155C0DC2A7923A100F540CB /* IntentType.swift in Sources */,
@@ -1486,6 +1505,7 @@
 				B191DD512A8BF157008196CD /* InteriorAPIManager.swift in Sources */,
 				B1F2BC642A7B5BA3005385E0 /* CLNavigationMenuView.swift in Sources */,
 				B16DFF472A8A161700642730 /* ModelTypeResponseDTO.swift in Sources */,
+				EDD3F0AF2A8DE3BC006CE38A /* CLSheetCapsule.swift in Sources */,
 				B16DFF412A895B8200642730 /* ResultOfCalculationOfFuelAndDisplacement.swift in Sources */,
 				B1604D4A2A83BECC00C7B07D /* MockAPIManager.swift in Sources */,
 				B155C0E02A7923AE00F540CB /* Container.swift in Sources */,

--- a/iOS/Catalog/Catalog.xcodeproj/project.pbxproj
+++ b/iOS/Catalog/Catalog.xcodeproj/project.pbxproj
@@ -180,6 +180,9 @@
 		EDD054002A8C02A900FBD23F /* QuotationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD053FF2A8C02A900FBD23F /* QuotationModel.swift */; };
 		EDD303FD2A8A09E600400DF9 /* HMGTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD303FC2A8A09E600400DF9 /* HMGTag.swift */; };
 		EDD304462A8A6AD300400DF9 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD304452A8A6AD300400DF9 /* API.swift */; };
+		EDDCA98D2A8D51F1003DFD43 /* QuotationSheetTop.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDCA98C2A8D51F1003DFD43 /* QuotationSheetTop.swift */; };
+		EDDCA98F2A8D553E003DFD43 /* QuotationExteriorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDCA98E2A8D553E003DFD43 /* QuotationExteriorView.swift */; };
+		EDDCA9912A8D5607003DFD43 /* QuotationInteriorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDCA9902A8D5607003DFD43 /* QuotationInteriorView.swift */; };
 		EDE434F12A8BFE75007BD0DE /* QuotationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE434F02A8BFE75007BD0DE /* QuotationIntent.swift */; };
 		EDF071A32A8CC588002AD0DB /* TrimDefaultOption.json in Resources */ = {isa = PBXBuildFile; fileRef = EDF071A22A8CC588002AD0DB /* TrimDefaultOption.json */; };
 		EDF071A52A8CC629002AD0DB /* TrimMaxMinPrice.json in Resources */ = {isa = PBXBuildFile; fileRef = EDF071A42A8CC629002AD0DB /* TrimMaxMinPrice.json */; };
@@ -394,6 +397,9 @@
 		EDD304372A8A64D600400DF9 /* ModelTypeRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelTypeRepository.swift; sourceTree = "<group>"; };
 		EDD304422A8A668B00400DF9 /* ModelTypeRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTypeRequest.swift; sourceTree = "<group>"; };
 		EDD304452A8A6AD300400DF9 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
+		EDDCA98C2A8D51F1003DFD43 /* QuotationSheetTop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotationSheetTop.swift; sourceTree = "<group>"; };
+		EDDCA98E2A8D553E003DFD43 /* QuotationExteriorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotationExteriorView.swift; sourceTree = "<group>"; };
+		EDDCA9902A8D5607003DFD43 /* QuotationInteriorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotationInteriorView.swift; sourceTree = "<group>"; };
 		EDE434F02A8BFE75007BD0DE /* QuotationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotationIntent.swift; sourceTree = "<group>"; };
 		EDF071A22A8CC588002AD0DB /* TrimDefaultOption.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TrimDefaultOption.json; sourceTree = "<group>"; };
 		EDF071A42A8CC629002AD0DB /* TrimMaxMinPrice.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TrimMaxMinPrice.json; sourceTree = "<group>"; };
@@ -916,6 +922,9 @@
 			isa = PBXGroup;
 			children = (
 				ED2B8CEB2A8D282F00F561FA /* QuotationCompleteView.swift */,
+				EDDCA9902A8D5607003DFD43 /* QuotationInteriorView.swift */,
+				EDDCA98E2A8D553E003DFD43 /* QuotationExteriorView.swift */,
+				EDDCA98C2A8D51F1003DFD43 /* QuotationSheetTop.swift */,
 			);
 			path = QuotationComplete;
 			sourceTree = "<group>";
@@ -1370,6 +1379,7 @@
 				B1604D6D2A85569400C7B07D /* DetailButtonStyle.swift in Sources */,
 				B16DFF342A89533300642730 /* ModelTypeOption.swift in Sources */,
 				B1604D382A8381BD00C7B07D /* TrimRequestDTO.swift in Sources */,
+				EDDCA98F2A8D553E003DFD43 /* QuotationExteriorView.swift in Sources */,
 				EDD303FD2A8A09E600400DF9 /* HMGTag.swift in Sources */,
 				B1F988E32A8B1D5A00C7B65F /* InteriorColorSelectionHorizontalList.swift in Sources */,
 				B1604D442A83943000C7B07D /* TrimSelectionRepository.swift in Sources */,
@@ -1406,6 +1416,7 @@
 				B1604D422A83935400C7B07D /* JSONLoader.swift in Sources */,
 				B1F2BC622A7B5B7A005385E0 /* CLNavigationMenuTitleView.swift in Sources */,
 				ED1A70A32A836F3700F7920F /* CarQuotation.swift in Sources */,
+				EDDCA98D2A8D51F1003DFD43 /* QuotationSheetTop.swift in Sources */,
 				B19436432A80AE2000C2FD69 /* CLOptionSelectAlertContentView.swift in Sources */,
 				ED1C70602A89C3810049D275 /* CLSimilarQuotationSlideView.swift in Sources */,
 				B191DD302A8B4E53008196CD /* CarColorType.swift in Sources */,
@@ -1429,6 +1440,7 @@
 				EDCF32C42A8A91D500C46A4B /* CLQuotationSummarySheet.swift in Sources */,
 				EDCF32F82A8B90D700C46A4B /* ExternalColorModel.swift in Sources */,
 				B1604D322A836DBE00C7B07D /* Request.swift in Sources */,
+				EDDCA9912A8D5607003DFD43 /* QuotationInteriorView.swift in Sources */,
 				EDF882572A8A708A0077558F /* ModelTypeRequestDTO.swift in Sources */,
 				B155C0DC2A7923A100F540CB /* IntentType.swift in Sources */,
 				EDA3CDD52A8243CC0001BB9C /* CLSimilarQuotationButton.swift in Sources */,

--- a/iOS/Catalog/Catalog/Assets.xcassets/Background/Contents.json
+++ b/iOS/Catalog/Catalog/Assets.xcassets/Background/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/Catalog/Catalog/Assets.xcassets/Background/QuotationCompleteBackground.imageset/Contents.json
+++ b/iOS/Catalog/Catalog/Assets.xcassets/Background/QuotationCompleteBackground.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "Rectangle 830183.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/Catalog/Catalog/Assets.xcassets/Background/QuotationCompleteBackground.imageset/Rectangle 830183.svg
+++ b/iOS/Catalog/Catalog/Assets.xcassets/Background/QuotationCompleteBackground.imageset/Rectangle 830183.svg
@@ -1,0 +1,18 @@
+<svg width="375" height="534" viewBox="0 0 375 534" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.9" filter="url(#filter0_b_8_44366)">
+<rect width="375" height="534" fill="url(#paint0_linear_8_44366)" fill-opacity="0.9"/>
+</g>
+<defs>
+<filter id="filter0_b_8_44366" x="-60" y="-60" width="495" height="654" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feGaussianBlur in="BackgroundImageFix" stdDeviation="30"/>
+<feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur_8_44366"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur_8_44366" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear_8_44366" x1="187.5" y1="0" x2="187.5" y2="560" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9CCAFF"/>
+<stop offset="0.0001" stop-color="#C9E2FF"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/iOS/Catalog/Catalog/CLBudgetSetting/CLBudgetRangeIntent.swift
+++ b/iOS/Catalog/Catalog/CLBudgetSetting/CLBudgetRangeIntent.swift
@@ -30,7 +30,7 @@ final class CLBudgetRangeIntent: ObservableObject {
     typealias ViewAction = CLBudgetRangeModel.ViewAction
 
     @Published var state: State = State(currentQuotationPrice: CLNumber(30000000),
-                                        budgetPrice: CLNumber(40000000))
+                                        budgetPrice: CLNumber(40000000), status: .default)
     var quotation = Quotation.shared
     var cancellable: Set<AnyCancellable> = []
 }

--- a/iOS/Catalog/Catalog/CLBudgetSetting/CLBudgetRangeModel.swift
+++ b/iOS/Catalog/Catalog/CLBudgetSetting/CLBudgetRangeModel.swift
@@ -10,6 +10,7 @@ import Foundation
 enum CLBudgetRangeModel {
 
   struct State: Equatable {
+    var status: CLBudgetRangeView.Status
     var currentQuotationPrice: CLNumber
     var budgetPrice: CLNumber
     var isExceedBudget: Bool
@@ -17,11 +18,12 @@ enum CLBudgetRangeModel {
     var minimumPrice: CLNumber = CLNumber(0)
     var maximumPrice: CLNumber = CLNumber(0)
 
-    init(currentQuotationPrice: CLNumber, budgetPrice: CLNumber) {
+    init(currentQuotationPrice: CLNumber, budgetPrice: CLNumber, status: CLBudgetRangeView.Status) {
       self.currentQuotationPrice = currentQuotationPrice
       self.budgetPrice = budgetPrice
       self.isExceedBudget = (currentQuotationPrice > budgetPrice)
       self.budgetGap = CLNumber(abs(currentQuotationPrice.value - budgetPrice.value))
+      self.status = status
     }
   }
 

--- a/iOS/Catalog/Catalog/CLBudgetSetting/View/CLBudgetRangeView.swift
+++ b/iOS/Catalog/Catalog/CLBudgetSetting/View/CLBudgetRangeView.swift
@@ -100,6 +100,7 @@ extension CLBudgetRangeView: View {
         }
         .padding(.horizontal, 12)
         .padding(.bottom, 20)
+        .padding(.top, 12)
         .onAppear {
           intent.send(action: .onAppear)
             if status == .similarQuotation {

--- a/iOS/Catalog/Catalog/CLBudgetSetting/View/CLBudgetRangeView.swift
+++ b/iOS/Catalog/Catalog/CLBudgetSetting/View/CLBudgetRangeView.swift
@@ -13,12 +13,6 @@ struct CLBudgetRangeView: IntentBindingType {
     var intent: CLBudgetRangeIntentType { container.intent }
     var state: CLBudgetRangeModel.State { intent.state }
 
-    @SwiftUI.State var status: CLBudgetRangeView.Status = .default {
-        didSet {
-            isFloatingExpanded = false
-        }
-    }
-
     @SwiftUI.State var isFloatingExpanded: Bool = false
 }
 
@@ -48,7 +42,7 @@ extension CLBudgetRangeView: View {
                 // MARK: - 예산범위 title
                 ZStack {
                     HStack {
-                        Text(status == .similarQuotation ? "유사견적 가격" : "예산 범위")
+                      Text(state.status == .similarQuotation ? "유사견적 가격" : "예산 범위")
                             .catalogFont(type: .HeadKRMedium14)
                             .foregroundColor(Color.gray50)
                         Spacer()
@@ -57,7 +51,7 @@ extension CLBudgetRangeView: View {
                         Spacer()
                         Text(attributedString)
                             .catalogFont(type: .TextKRRegular12)
-                        if status != .similarQuotation {
+                      if state.status != .similarQuotation {
                             Button {
                                 isFloatingExpanded.toggle()
                             } label: {
@@ -72,13 +66,13 @@ extension CLBudgetRangeView: View {
 
                 if isFloatingExpanded {
                     // MARK: - 슬라이더
-                    switch status {
+                    switch state.status {
                       case .`default`, .complete:
                             CLSliderView(intent: intent,
                                          minimumBudget: state.minimumPrice,
                                          maximumBudget: state.maximumPrice,
                                          currentQuotationPrice: state.currentQuotationPrice,
-                                         status: status,
+                                         status: state.status,
                                          budgetPriceBinding: budgetPriceBinding,
                                          isExceedBudget: isExceedBudgetBinding)
                       case .similarQuotation:
@@ -88,7 +82,7 @@ extension CLBudgetRangeView: View {
                                                         similarQuotationPrice: CLNumber(41000000))
                     }
                     // MARK: - 확인 버튼
-                    if status == .complete {
+                    if state.status == .complete {
                         CLSimilarQuotationButton(isExceedBudget: isExceedBudgetBinding)
                     }
                 }
@@ -103,7 +97,7 @@ extension CLBudgetRangeView: View {
         .padding(.top, 12)
         .onAppear {
           intent.send(action: .onAppear)
-            if status == .similarQuotation {
+            if state.status == .similarQuotation {
                 isFloatingExpanded = true
             }
         }
@@ -122,11 +116,11 @@ extension CLBudgetRangeView {
 
 extension CLBudgetRangeView {
     var attributedString: AttributedString {
-        let headString = ((status == .similarQuotation) ? "내 견적 " : "설정한 예산") +
-      ((!state.isExceedBudget && (status == .default)) ? "까지 " : "보다 ")
+        let headString = ((state.status == .similarQuotation) ? "내 견적 " : "설정한 예산") +
+      ((!state.isExceedBudget && (state.status == .default)) ? "까지 " : "보다 ")
         let budgetString = state.budgetGap.won
         let tailString = (state.isExceedBudget ?
-                          "더 들었어요" : (status == .default) ? "남았어요" : (status == .complete) ? "아꼈어요" : "비싸요")
+                          "더 들었어요" : (state.status == .default) ? "남았어요" : (state.status == .complete) ? "아꼈어요" : "비싸요")
         var text = AttributedString(headString + budgetString + " " + tailString + ".")
         guard let range = text.range(of: budgetString ) else { return "" }
         text.foregroundColor = Color.gray50
@@ -136,13 +130,14 @@ extension CLBudgetRangeView {
     }
 }
 
-struct CLBudgetRangeView_Previews: PreviewProvider {
+ struct CLBudgetRangeView_Previews: PreviewProvider {
     static var previews: some View {
         CLBudgetRangeView.build(
             intent: CLBudgetRangeIntent(initialState: .init(
               currentQuotationPrice: CLNumber(40000000),
-              budgetPrice: CLNumber(40750000))
+              budgetPrice: CLNumber(40750000),
+              status: .default)
             )
         )
     }
-}
+ }

--- a/iOS/Catalog/Catalog/CLNavigation/Intent/CLNavigationIntent.swift
+++ b/iOS/Catalog/Catalog/CLNavigation/Intent/CLNavigationIntent.swift
@@ -19,6 +19,7 @@ final class CLNavigationIntent: ObservableObject {
   // MARK: - Internal
 
   @Published var state: State = State(currentPage: 0)
+  var quotation = Quotation.shared
   var cancellable: Set<AnyCancellable> = []
 }
 
@@ -30,6 +31,9 @@ extension CLNavigationIntent: CLNavigationIntentType, IntentType {
   func mutate(action: CLNavigationModel.ViewAction, viewEffect: (() -> Void)?) {
     switch action {
     case .onTapNavTab(let index):
+        if index != 0 && quotation.state.quotation == nil {
+          print("페이지 이동 불가")
+        }
       state.currentPage = index
     case .onTapFinish:
       print("didTapFinish")

--- a/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationMenuTitleView.swift
+++ b/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationMenuTitleView.swift
@@ -16,12 +16,12 @@ struct CLNavigationMenuTitleView: View {
 
     var color: Color {
       switch self {
-      case .completed:
-        return Color.primary200
-      case .active:
-        return Color.primary0
-      case .inactive:
-        return Color.gray200
+        case .completed:
+          return Color.primary200
+        case .active:
+          return Color.primary0
+        case .inactive:
+          return Color.gray200
       }
     }
   }
@@ -36,12 +36,13 @@ struct CLNavigationMenuTitleView: View {
     Button {
       currentPage = page
     } label: {
-      VStack {
-        Spacer()
+      VStack(spacing: 0) {
         if currentPage == page {
           Text(navigationMenuTitle)
             .catalogFont(type: .HeadKRMedium14)
             .foregroundColor(Status.active.color)
+            .frame(height: 22)
+            .padding(.bottom, 6)
           Color.black
             .frame(height: 2)
             .matchedGeometryEffect(id: "underline", in: namespace, properties: .frame)
@@ -49,6 +50,8 @@ struct CLNavigationMenuTitleView: View {
           Text(navigationMenuTitle)
             .catalogFont(type: .HeadKRMedium14)
             .foregroundColor(status.color)
+            .frame(height: 22)
+            .padding(.bottom, 6)
           Color.clear.frame(height: 2)
         }
       }

--- a/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationMenuView.swift
+++ b/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationMenuView.swift
@@ -14,7 +14,7 @@ struct CLNavigationMenuView: View {
   @Namespace var namespace
   var navigationMenuTitles = ["트림", "타입", "외장", "내장", "옵션", "완료"]
   var body: some View {
-    ScrollView(.horizontal, showsIndicators: false) {
+    VStack(spacing: 0) {
       HStack(spacing: 11) {
         ForEach(Array(zip(self.navigationMenuTitles.indices,
                           self.navigationMenuTitles)), id: \.0) { index, name in
@@ -22,12 +22,12 @@ struct CLNavigationMenuView: View {
                                     status: $menuStatus[index], namespace: namespace.self,
                                     navigationMenuTitle: name,
                                     page: index)
-            .frame(width: 52)
+          .frame(width: 52)
         }
       }
-      .padding(.horizontal, 20)
+     .background(Color.white)
+      Divider().frame(height: 2).foregroundColor(Color.gray200).offset(y: -2)
     }
-    .background(Color.white)
-    .frame(height: 30)
+
   }
 }

--- a/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationView.swift
+++ b/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationView.swift
@@ -31,7 +31,7 @@ extension CLNavigationView {
 
 extension CLNavigationView: View {
   var body: some View {
-    VStack {
+    VStack(spacing: 0) {
       CLTopNaviBar(intent: intent)
       CLNavigationMenuView(currentPage: currentPageBinding, menuStatus: $menuStatus)
       ZStack {

--- a/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationView.swift
+++ b/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationView.swift
@@ -63,12 +63,17 @@ extension CLNavigationView: View {
         }
         .onAppear { UIScrollView.appearance().isScrollEnabled = false }
         .tabViewStyle(.page(indexDisplayMode: .never))
-        if state.currentPage != 0 {
+        if state.currentPage != 0 && state.currentPage != 5 {
           CLBudgetRangeView.build(
             intent: CLBudgetRangeIntent(initialState:
                 .init(currentQuotationPrice: quotation.state.totalPrice,
-                      budgetPrice: (quotation.state.maxPrice + quotation.state.minPrice) / CLNumber(2)))
+                      budgetPrice: (quotation.state.maxPrice + quotation.state.minPrice) / CLNumber(2), status: .default))
           )
+        } else if state.currentPage == 5 {
+          CLBudgetRangeView.build(
+            intent: CLBudgetRangeIntent(initialState:
+                .init(currentQuotationPrice: quotation.state.totalPrice,
+                      budgetPrice: (quotation.state.maxPrice + quotation.state.minPrice) / CLNumber(2), status: .complete)))
         }
       }
       if state.currentPage != 0 {

--- a/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationView.swift
+++ b/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationView.swift
@@ -111,3 +111,13 @@ struct CLNavigationView_Previews: PreviewProvider {
     return CLNavigationView.build(intent: CLNavigationIntent(initialState: .init(currentPage: 0)))
   }
 }
+
+extension ShapeStyle where Self == Color {
+  static var random: Color {
+    Color(
+      red: .random(in: 0...1),
+      green: .random(in: 0...1),
+      blue: .random(in: 0...1)
+    )
+  }
+}

--- a/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationView.swift
+++ b/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationView.swift
@@ -48,7 +48,7 @@ extension CLNavigationView: View {
             intent: .init(initialState: .init(selectedTrimID: 2, selectedColorId: 1, trimColors: []),
                           repository: InteriorColorSelectionRepository(requestManager: RequestManager(apiManager: InteriorAPIManager())))).tag(3)
           MockView(image: mockImageName[4]).tag(4)
-          MockView(image: mockImageName[5]).tag(5)
+          QuotationCompleteView().tag(5)
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
         if state.currentPage != 0 {

--- a/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationView.swift
+++ b/iOS/Catalog/Catalog/CLNavigation/View/CLNavigationView.swift
@@ -39,17 +39,29 @@ extension CLNavigationView: View {
           TrimSelectionView.build(intent: TrimSelectionIntent(
             initialState: .init(
               carId: 1),
-            repository: TrimSelectionRepository(), quotation: Quotation.shared, navigationIntent: intent)).tag(0)
-          ModelTypeSelectionContainerView.build(intent: .init(initialState: .mock(), repository: MockModelTypeRepository())).tag(1)
+            repository: TrimSelectionRepository(), quotation: Quotation.shared, navigationIntent: intent))
+          .tag(0)
+          ModelTypeSelectionContainerView.build(intent: .init(initialState: .mock(), repository: MockModelTypeRepository()))
+            .tag(1)
+
           ExternalSelectionContainerView.build(
             intent: .init(initialState: .init(selectedTrimId: 2),
-                          repository: ExteriorColorRepository(requestManager: RequestManager(apiManager: ExteriorColorAPIManager())))).tag(2)
+                          repository: ExteriorColorRepository(requestManager: RequestManager(apiManager: ExteriorColorAPIManager()))))
+          .tag(2)
+
           InteriorColorSelectionView.build(
             intent: .init(initialState: .init(selectedTrimID: 2, selectedColorId: 1, trimColors: []),
-                          repository: InteriorColorSelectionRepository(requestManager: RequestManager(apiManager: InteriorAPIManager())))).tag(3)
-          MockView(image: mockImageName[4]).tag(4)
-          QuotationCompleteView().tag(5)
+                          repository: InteriorColorSelectionRepository(requestManager: RequestManager(apiManager: InteriorAPIManager()))))
+          .tag(3)
+
+          MockView(image: mockImageName[4])
+            .tag(4)
+
+          QuotationCompleteView()
+            .tag(5)
+
         }
+        .onAppear { UIScrollView.appearance().isScrollEnabled = false }
         .tabViewStyle(.page(indexDisplayMode: .never))
         if state.currentPage != 0 {
           CLBudgetRangeView.build(

--- a/iOS/Catalog/Catalog/CLNavigation/View/CLTopNaviBar.swift
+++ b/iOS/Catalog/Catalog/CLNavigation/View/CLTopNaviBar.swift
@@ -39,5 +39,6 @@ struct CLTopNaviBar: View {
         Image("logo")
       }
     }
+    .padding(.bottom, 10)
   }
 }

--- a/iOS/Catalog/Catalog/Component/LeadingTitle.swift
+++ b/iOS/Catalog/Catalog/Component/LeadingTitle.swift
@@ -1,0 +1,27 @@
+//
+//  LeadingTitle.swift
+//  Catalog
+//
+//  Created by 이수민 on 2023/08/17.
+//
+
+import SwiftUI
+
+struct LeadingTitle: View {
+    let title: String
+    var body: some View {
+      HStack {
+        Text(title)
+          .catalogFont(type: .HeadKRMedium16)
+        Spacer()
+      }
+      .padding(.leading, 20)
+      .padding(.vertical, 12)
+    }
+}
+
+struct LeadingTitle_Previews: PreviewProvider {
+    static var previews: some View {
+      LeadingTitle(title: "트림을 선택해주세요")
+    }
+}

--- a/iOS/Catalog/Catalog/Component/Modal/CLSheetCapsule.swift
+++ b/iOS/Catalog/Catalog/Component/Modal/CLSheetCapsule.swift
@@ -1,0 +1,25 @@
+//
+//  CLSheetCapsule.swift
+//  Catalog
+//
+//  Created by 이수민 on 2023/08/17.
+//
+
+import SwiftUI
+
+struct CLSheetCapsule: View {
+    let height: CGFloat
+    var body: some View {
+      Capsule()
+        .fill(Color.gray300)
+        .frame(width: 39, height: height)
+        .padding(.bottom, 5)
+        .padding(.top, 5)
+    }
+}
+
+struct CLSheetCapsule_Previews: PreviewProvider {
+    static var previews: some View {
+      CLSheetCapsule(height: 4)
+    }
+}

--- a/iOS/Catalog/Catalog/Font/Font+.swift
+++ b/iOS/Catalog/Catalog/Font/Font+.swift
@@ -25,6 +25,7 @@ enum CatalogTextType {
 
   case CaptionENMedium14
   case CaptionENMedium12
+  case HeadKRBold65
   case HeadKRBold32
   case HeadKRBold26
   case HeadKRBold24
@@ -146,6 +147,8 @@ extension CatalogTextType {
       return -0.3
     case .HeadENRegular28:
       return -0.1
+    case .HeadKRBold65:
+      return -0.3
     }
   }
 }
@@ -165,6 +168,8 @@ extension CatalogTextType {
       return UIFont(name: "HyundaiSansHeadMedium", size: 20)!
     case .HeadENBold10:
       return UIFont(name: "HyundaiSansHead-Bold", size: 10)!
+    case .HeadKRBold65:
+        return UIFont(name: "HyundaiSansTextKROTFBold", size: 65.24)!
     case .HeadKRBold32:
       return UIFont(name: "HyundaiSansHeadKROTFBold", size: 32)!
     case .HeadKRBold26:
@@ -237,6 +242,7 @@ extension CatalogTextType {
       return UIFont(name: "HyundaiSansHeadMedium", size: 10)!
     case .HeadENRegular28:
       return UIFont(name: "HyundaiSansHead", size: 28)!
+
     }
   }
 }
@@ -328,6 +334,8 @@ extension CatalogTextType {
       return 18
     case .HeadENRegular28:
       return 35
+    case .HeadKRBold65:
+      return 81.55
     }
   }
 }

--- a/iOS/Catalog/Catalog/ModelTypeSelection/Domain/Entity/MaxOutputFromEngine.swift
+++ b/iOS/Catalog/Catalog/ModelTypeSelection/Domain/Entity/MaxOutputFromEngine.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct MaxOutputFromEngine: Codable {
-  var output: Double
-  var minRPM: Int
-  var maxRPM: Int
+struct MaxOutputFromEngine {
+  var output: Double?
+  var minRPM: Int?
+  var maxRPM: Int?
 }

--- a/iOS/Catalog/Catalog/ModelTypeSelection/Model/ModelTypeModels.swift
+++ b/iOS/Catalog/Catalog/ModelTypeSelection/Model/ModelTypeModels.swift
@@ -7,18 +7,18 @@
 
 import Foundation
 
-struct PowerTrainModel: Codable {
+struct PowerTrainModel {
   var id: Int
   var name: String
   var price: CLNumber
   var choiceRaatio: Int
   var description: String
   var image: URL?
-  var maxOutput: MaxOutputFromEngine
-  var maxTorque: MaxTorqueFromEngine
+  var maxOutput: MaxOutputFromEngine?
+  var maxTorque: MaxTorqueFromEngine?
 }
 
-struct BodyTypeModel: Codable {
+struct BodyTypeModel {
   var id: Int
   var name: String
   var price: CLNumber
@@ -27,7 +27,7 @@ struct BodyTypeModel: Codable {
   var image: URL?
 }
 
-struct DriveTrainModel: Codable {
+struct DriveTrainModel {
   var id: Int
   var name: String
   var price: CLNumber

--- a/iOS/Catalog/Catalog/ModelTypeSelection/View/ModelTypeSelectionContainerView/ModelTypeSelectionContainerView.swift
+++ b/iOS/Catalog/Catalog/ModelTypeSelection/View/ModelTypeSelectionContainerView/ModelTypeSelectionContainerView.swift
@@ -26,6 +26,7 @@ extension ModelTypeSelectionContainerView: View {
     ScrollView {
       ZStack {
         LazyVStack(alignment: .leading) {
+          Spacer().frame(height: 72)
           Text("모델타입을 선택해주세요")
             .catalogFont(type: .HeadKRMedium18)
             .padding(.horizontal, 16)

--- a/iOS/Catalog/Catalog/Quotation/QuotationModel.swift
+++ b/iOS/Catalog/Catalog/Quotation/QuotationModel.swift
@@ -14,7 +14,6 @@ enum QuotationModel {
     var quotation: CarQuotation?
     var minPrice: CLNumber
     var maxPrice: CLNumber
-
   }
 
   enum ViewAction {

--- a/iOS/Catalog/Catalog/Quotation/View/CLQuotationPriceBar.swift
+++ b/iOS/Catalog/Catalog/Quotation/View/CLQuotationPriceBar.swift
@@ -45,9 +45,8 @@ struct CLQuotationPriceBar: View {
                     }
                 }
                 .padding(.trailing, 20)
-                .padding(.vertical, 8)
             }
-            .frame(height: 58)
+            .frame(height: 52)
         }
     }
 }

--- a/iOS/Catalog/Catalog/QuotationComplete/DetailQuotationList.swift
+++ b/iOS/Catalog/Catalog/QuotationComplete/DetailQuotationList.swift
@@ -1,0 +1,22 @@
+//
+//  DetailQuotationList.swift
+//  Catalog
+//
+//  Created by 이수민 on 2023/08/17.
+//
+
+import SwiftUI
+
+struct DetailQuotationList: View {
+    var body: some View {
+      DetailQuotationTitle(title: "모델타입")
+      DetailQuotationTitle(title: "색상")
+      DetailQuotationTitle(title: "추가옵션")
+    }
+}
+
+struct DetailQuotationList_Previews: PreviewProvider {
+    static var previews: some View {
+        DetailQuotationList()
+    }
+}

--- a/iOS/Catalog/Catalog/QuotationComplete/DetailQuotationTitle.swift
+++ b/iOS/Catalog/Catalog/QuotationComplete/DetailQuotationTitle.swift
@@ -1,0 +1,36 @@
+//
+//  DetailQuotationTitle.swift
+//  Catalog
+//
+//  Created by 이수민 on 2023/08/17.
+//
+
+import SwiftUI
+
+struct DetailQuotationTitle: View {
+    var title: String
+    @State var isFloating: Bool = false
+    var body: some View {
+      ZStack {
+        LeadingTitle(title: title)
+        HStack {
+          Spacer()
+          Button {
+            isFloating.toggle()
+          } label: {
+            isFloating ? Image( "black_arrow_up") : Image( "black_arrow_down")
+          }
+          .padding(.trailing, 20)
+          .buttonStyle(.plain)
+
+        }
+      }
+      .background(Color("background2"))
+    }
+}
+
+struct DetailQuotationTitle_Previews: PreviewProvider {
+    static var previews: some View {
+      DetailQuotationTitle(title: "모델타입")
+    }
+}

--- a/iOS/Catalog/Catalog/QuotationComplete/QuotationCompleteSheet.swift
+++ b/iOS/Catalog/Catalog/QuotationComplete/QuotationCompleteSheet.swift
@@ -1,0 +1,64 @@
+//
+//  QuotationCompleteSheet.swift
+//  Catalog
+//
+//  Created by 이수민 on 2023/08/17.
+//
+
+import SwiftUI
+
+struct QuotationCompleteSheet: View {
+    var quotation = Quotation.shared
+    var body: some View {
+      ScrollView {
+        LazyVStack {
+          // capsule
+          CLSheetCapsule(height: 4)
+
+          // 요약견적 제목
+          LeadingTitle(title: "요약견적")
+
+          // 요약 견적
+          HStack(spacing: 46) {
+            VStack(alignment: .leading, spacing: 1) {
+              Text("모델")
+                .catalogFont(type: .TextKRRegular12)
+                .foregroundColor(Color.gray600)
+              Text((quotation.state.quotation?.trim.name ?? "") + "(르블랑)" )
+                .catalogFont(type: .HeadKRMedium18)
+                .foregroundColor(Color.gray900)
+            }
+            VStack(alignment: .leading, spacing: 1) {
+              Text("평균연비")
+                .catalogFont(type: .TextKRRegular12)
+                .foregroundColor(Color.gray600)
+              Text("2,199cc")
+                .catalogFont(type: .HeadKRMedium18)
+                .foregroundColor(Color.gray900)
+            }
+            VStack(alignment: .leading, spacing: 1) {
+              Text("배기량")
+                .catalogFont(type: .TextKRRegular12)
+                .foregroundColor(Color.gray600)
+              Text("12km/I")
+                .catalogFont(type: .HeadKRMedium18)
+                .foregroundColor(Color.gray900)
+            }
+          }
+          .frame(maxWidth: .infinity, minHeight: 95)
+          .padding(.horizontal, 21)
+          .background(Color.skyBlueCardBG)
+
+          LeadingTitle(title: "상세견적")
+          DetailQuotationList()
+        }
+      }
+
+    }
+}
+
+struct QuotationCompleteSheet_Previews: PreviewProvider {
+    static var previews: some View {
+        QuotationCompleteSheet()
+    }
+}

--- a/iOS/Catalog/Catalog/QuotationComplete/QuotationCompleteView.swift
+++ b/iOS/Catalog/Catalog/QuotationComplete/QuotationCompleteView.swift
@@ -1,0 +1,60 @@
+//
+//  QuotationCompleteView.swift
+//  Catalog
+//
+//  Created by 이수민 on 2023/08/17.
+//
+
+import SwiftUI
+
+struct QuotationCompleteView {
+  var quotation = Quotation.shared
+  let modalTopHeight: CGFloat = 30
+  let titleTopPadding: CGFloat = 177
+  let externalImageHeight: CGFloat = 222
+  @SwiftUI.State var isExternal: Bool = true
+}
+
+extension QuotationCompleteView: View {
+  var body: some View {
+    ZStack {
+      if isExternal {
+        VStack {
+          Spacer().frame(height: titleTopPadding)
+          Text(quotation.state.quotation?.trim.name ?? "")
+            .catalogFont(type: .HeadKRBold65)
+            .foregroundColor(.white)
+          AsyncImage(url: quotation.state.quotation?.trim.externalImage) { image in
+            image
+              .resizable()
+              .frame(maxWidth: .infinity, maxHeight: externalImageHeight)
+          } placeholder: {
+            EmptyView()
+          }
+          Spacer()
+        }
+      } else {
+        AsyncImage(url: quotation.state.quotation?.trim.internalImage ) { image in
+          image
+            .resizable()
+        } placeholder: {
+          EmptyView()
+        }
+      }
+      VStack {
+        Spacer()
+        CLToggle(isLeft: $isExternal)
+      }
+    }
+    .background(
+      Image("QuotationCompleteBackground")
+        .resizable()
+    )
+  }
+}
+
+struct QuotationCompleteView_Previews: PreviewProvider {
+    static var previews: some View {
+        QuotationCompleteView()
+    }
+}

--- a/iOS/Catalog/Catalog/QuotationComplete/QuotationCompleteView.swift
+++ b/iOS/Catalog/Catalog/QuotationComplete/QuotationCompleteView.swift
@@ -12,6 +12,8 @@ struct QuotationCompleteView {
   let modalTopHeight: CGFloat = 30
   let titleTopPadding: CGFloat = 177
   let externalImageHeight: CGFloat = 222
+  let totalHeight: CGFloat = 534
+  var (positionX, positionY): (CGFloat, CGFloat) = (0, 0)
   @SwiftUI.State var isExternal: Bool = true
 }
 
@@ -33,28 +35,45 @@ extension QuotationCompleteView: View {
           }
           Spacer()
         }
+        .background(
+          Image("QuotationCompleteBackground")
+            .resizable()
+        )
       } else {
-        AsyncImage(url: quotation.state.quotation?.trim.internalImage ) { image in
-          image
-            .scaledToFill()
-        } placeholder: {
-          EmptyView()
+
+        ZStack {
+          GeometryReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                    AsyncImage(url: quotation.state.quotation?.trim.internalImage) { img in
+                      img
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                    } placeholder: {
+                      EmptyView()
+                    }
+              }
+            .frame(minWidth: proxy.size.width, maxHeight: proxy.size.height)
+          }
         }
       }
       VStack {
         Spacer()
         CLToggle(isLeft: $isExternal)
+          .padding(.vertical, 8)
       }
     }
-    .background(
-      Image("QuotationCompleteBackground")
-        .resizable()
-    )
   }
 }
 
 struct QuotationCompleteView_Previews: PreviewProvider {
-    static var previews: some View {
-        QuotationCompleteView()
-    }
+  static var previews: some View {
+    QuotationCompleteView()
+  }
+}
+
+struct ScrollOffsetKey: PreferenceKey {
+  static var defaultValue: CGFloat = .zero
+  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+    value += nextValue()
+  }
 }

--- a/iOS/Catalog/Catalog/QuotationComplete/QuotationCompleteView.swift
+++ b/iOS/Catalog/Catalog/QuotationComplete/QuotationCompleteView.swift
@@ -9,9 +9,6 @@ import SwiftUI
 
 struct QuotationCompleteView {
   var quotation = Quotation.shared
-  let modalTopHeight: CGFloat = 30
-  let titleTopPadding: CGFloat = 177
-  let externalImageHeight: CGFloat = 222
   let totalHeight: CGFloat = 534
   var (positionX, positionY): (CGFloat, CGFloat) = (0, 0)
   @SwiftUI.State var isExternal: Bool = true
@@ -19,49 +16,22 @@ struct QuotationCompleteView {
 
 extension QuotationCompleteView: View {
   var body: some View {
-    ZStack {
-      if isExternal {
+    VStack {
+      ZStack {
+        if isExternal {
+            QuotationExteriorView()
+        } else {
+            QuotationInteriorView()
+        }
         VStack {
-          Spacer().frame(height: titleTopPadding)
-          Text(quotation.state.quotation?.trim.name ?? "")
-            .catalogFont(type: .HeadKRBold65)
-            .foregroundColor(.white)
-          AsyncImage(url: quotation.state.quotation?.trim.externalImage) { image in
-            image
-              .resizable()
-              .frame(maxWidth: .infinity, maxHeight: externalImageHeight)
-          } placeholder: {
-            EmptyView()
-          }
           Spacer()
-        }
-        .background(
-          Image("QuotationCompleteBackground")
-            .resizable()
-        )
-      } else {
-
-        ZStack {
-          GeometryReader { proxy in
-            ScrollView(.horizontal, showsIndicators: false) {
-                    AsyncImage(url: quotation.state.quotation?.trim.internalImage) { img in
-                      img
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                    } placeholder: {
-                      EmptyView()
-                    }
-              }
-            .frame(minWidth: proxy.size.width, maxHeight: proxy.size.height)
-          }
+          CLToggle(isLeft: $isExternal)
+            .padding(.vertical, 8)
         }
       }
-      VStack {
-        Spacer()
-        CLToggle(isLeft: $isExternal)
-          .padding(.vertical, 8)
-      }
+      QuotationSheetTop()
     }
+
   }
 }
 

--- a/iOS/Catalog/Catalog/QuotationComplete/QuotationCompleteView.swift
+++ b/iOS/Catalog/Catalog/QuotationComplete/QuotationCompleteView.swift
@@ -12,6 +12,7 @@ struct QuotationCompleteView {
   let totalHeight: CGFloat = 534
   var (positionX, positionY): (CGFloat, CGFloat) = (0, 0)
   @SwiftUI.State var isExternal: Bool = true
+  @State var showSheet: Bool = false
 }
 
 extension QuotationCompleteView: View {
@@ -30,6 +31,17 @@ extension QuotationCompleteView: View {
         }
       }
       QuotationSheetTop()
+        .gesture(
+          DragGesture()
+            .onChanged { gesture in
+             if gesture.translation.height < 20 {
+                showSheet = true
+              }
+            }
+          )
+    }
+    .sheet(isPresented: $showSheet) {
+      QuotationCompleteSheet()
     }
 
   }

--- a/iOS/Catalog/Catalog/QuotationComplete/QuotationCompleteView.swift
+++ b/iOS/Catalog/Catalog/QuotationComplete/QuotationCompleteView.swift
@@ -36,7 +36,7 @@ extension QuotationCompleteView: View {
       } else {
         AsyncImage(url: quotation.state.quotation?.trim.internalImage ) { image in
           image
-            .resizable()
+            .scaledToFill()
         } placeholder: {
           EmptyView()
         }

--- a/iOS/Catalog/Catalog/QuotationComplete/QuotationExteriorView.swift
+++ b/iOS/Catalog/Catalog/QuotationComplete/QuotationExteriorView.swift
@@ -1,0 +1,42 @@
+//
+//  QuotationExternalView.swift
+//  Catalog
+//
+//  Created by 이수민 on 2023/08/17.
+//
+
+import SwiftUI
+
+struct QuotationExteriorView: View {
+  var quotation = Quotation.shared
+  let modalTopHeight: CGFloat = 30
+  let titleTopPadding: CGFloat = 177
+  let externalImageHeight: CGFloat = 222
+
+    var body: some View {
+      VStack {
+        Spacer().frame(height: titleTopPadding)
+        Text(quotation.state.quotation?.trim.name ?? "")
+          .catalogFont(type: .HeadKRBold65)
+          .foregroundColor(.white)
+        AsyncImage(url: quotation.state.quotation?.trim.externalImage) { image in
+          image
+            .resizable()
+            .frame(maxWidth: .infinity, maxHeight: externalImageHeight)
+        } placeholder: {
+          EmptyView()
+        }
+        Spacer()
+      }
+      .background(
+        Image("QuotationCompleteBackground")
+          .resizable()
+      )
+    }
+}
+
+struct QuotationExternalView_Previews: PreviewProvider {
+    static var previews: some View {
+        QuotationExteriorView()
+    }
+}

--- a/iOS/Catalog/Catalog/QuotationComplete/QuotationInteriorView.swift
+++ b/iOS/Catalog/Catalog/QuotationComplete/QuotationInteriorView.swift
@@ -1,0 +1,34 @@
+//
+//  QuotationInteriorView.swift
+//  Catalog
+//
+//  Created by 이수민 on 2023/08/17.
+//
+
+import SwiftUI
+
+struct QuotationInteriorView: View {
+  var quotation = Quotation.shared
+  var body: some View {
+    ZStack {
+      GeometryReader { proxy in
+        ScrollView(.horizontal, showsIndicators: false) {
+          AsyncImage(url: quotation.state.quotation?.trim.internalImage) { img in
+            img
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+          } placeholder: {
+            EmptyView()
+          }
+        }
+        .frame(minWidth: proxy.size.width, maxHeight: proxy.size.height)
+      }
+    }
+  }
+}
+
+struct QuotationInteriorView_Previews: PreviewProvider {
+  static var previews: some View {
+    QuotationInteriorView()
+  }
+}

--- a/iOS/Catalog/Catalog/QuotationComplete/QuotationSheetTop.swift
+++ b/iOS/Catalog/Catalog/QuotationComplete/QuotationSheetTop.swift
@@ -1,0 +1,32 @@
+//
+//  QuotationSheetTop.swift
+//  Catalog
+//
+//  Created by 이수민 on 2023/08/17.
+//
+
+import SwiftUI
+
+struct QuotationSheetTop: View {
+    var body: some View {
+      VStack {
+        Capsule()
+          .fill(Color.gray300)
+          .frame(width: 39, height: 4)
+          .padding(.bottom, 5)
+          .padding(.top, 5)
+      }
+      .frame(maxWidth: .infinity, maxHeight: 30)
+      .background(
+        RoundedRectangle(cornerRadius: 20)
+          .fill(.white)
+          .shadow(radius: 1, x: 0, y: -1)
+      )
+    }
+}
+
+struct QuotationSheetTop_Previews: PreviewProvider {
+    static var previews: some View {
+        QuotationSheetTop()
+    }
+}

--- a/iOS/Catalog/Catalog/QuotationComplete/QuotationSheetTop.swift
+++ b/iOS/Catalog/Catalog/QuotationComplete/QuotationSheetTop.swift
@@ -18,8 +18,9 @@ struct QuotationSheetTop: View {
       }
       .frame(maxWidth: .infinity, maxHeight: 30)
       .background(
-        RoundedRectangle(cornerRadius: 20)
+        Rectangle()
           .fill(.white)
+          .cornerRadius(20, corners: [.topLeft, .topRight])
           .shadow(radius: 1, x: 0, y: -1)
       )
     }
@@ -28,5 +29,22 @@ struct QuotationSheetTop: View {
 struct QuotationSheetTop_Previews: PreviewProvider {
     static var previews: some View {
         QuotationSheetTop()
+    }
+}
+
+extension View {
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape( RoundedCorner(radius: radius, corners: corners) )
+    }
+}
+
+struct RoundedCorner: Shape {
+
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
     }
 }

--- a/iOS/Catalog/Catalog/TrimSelection/Data/Mock/TrimMockRepository.swift
+++ b/iOS/Catalog/Catalog/TrimSelection/Data/Mock/TrimMockRepository.swift
@@ -9,7 +9,7 @@ import Foundation
 
 final class TrimMockRepository: TrimSelectionRepositoryProtocol {
 
-  func fetchTrims(in carId: Int) async throws -> [Trim] {
+  func fetchTrims(of carId: Int) async throws -> [Trim] {
     let manager = RequestManager(apiManager: MockAPIManager())
     guard let data = JSONLoader.load(with: "Trim") else { return [] }
     let url = URL(string: "https://\(API.host):8080/carId/\(carId)")!
@@ -20,7 +20,7 @@ final class TrimMockRepository: TrimSelectionRepositoryProtocol {
       return dto.toDomain()
     }
 
-  func fetchDefaultOptionsByTrim(in trim: Trim) async throws -> CarQuotation {
+  func fetchDefaultOptionsByTrim(of trim: Trim) async throws -> CarQuotation {
     let manager = RequestManager(apiManager: MockAPIManager())
     guard let data = JSONLoader.load(with: "TrimDefaultOption") else { throw MockError.JSONError }
     let url = URL(string: "https://\(API.host):8080/trim/\(trim.id)/default-options")!
@@ -34,7 +34,7 @@ final class TrimMockRepository: TrimSelectionRepositoryProtocol {
     return try dto.toDomain(trim: trim)
   }
 
-  func fetchMinMaxPriceByTrim(in trimId: Int) async throws -> (CLNumber, CLNumber) {
+  func fetchMinMaxPriceByTrim(of trimId: Int) async throws -> (CLNumber, CLNumber) {
     let manager = RequestManager(apiManager: MockAPIManager())
     guard let data = JSONLoader.load(with: "TrimMaxMinPrice") else { throw MockError.JSONError }
     let url = URL(string: "https://\(API.host):8080/trim/\(trimId)/price-range")!

--- a/iOS/Catalog/Catalog/TrimSelection/Data/TrimSelectionRepository.swift
+++ b/iOS/Catalog/Catalog/TrimSelection/Data/TrimSelectionRepository.swift
@@ -8,29 +8,29 @@
 import Foundation
 
 protocol TrimSelectionRepositoryProtocol {
-  func fetchTrims(in vehicleId: Int) async throws -> [Trim]
-  func fetchDefaultOptionsByTrim(in trim: Trim) async throws -> CarQuotation
-  func fetchMinMaxPriceByTrim(in trimId: Int) async throws -> (CLNumber, CLNumber)
+  func fetchTrims(of vehicleId: Int) async throws -> [Trim]
+  func fetchDefaultOptionsByTrim(of trim: Trim) async throws -> CarQuotation
+  func fetchMinMaxPriceByTrim(of trimId: Int) async throws -> (CLNumber, CLNumber)
 }
 
 final class TrimSelectionRepository: TrimSelectionRepositoryProtocol {
 
   private let trimSelectionRequestManager: RequestManagerProtocol = RequestManager(apiManager: TrimAPIManager())
 
-  func fetchTrims(in carId: Int) async throws -> [Trim] {
+  func fetchTrims(of carId: Int) async throws -> [Trim] {
     let dto: [TrimDTO] = try await trimSelectionRequestManager
       .perform(TrimSelectionRequest.fetchTrimList(carId: carId))
     return dto.compactMap { try? $0.toDomain() }
   }
 
-  func fetchDefaultOptionsByTrim(in trim: Trim) async throws -> CarQuotation {
+  func fetchDefaultOptionsByTrim(of trim: Trim) async throws -> CarQuotation {
     let request = TrimSelectionRequest.fetchDefaultOption(trimId: trim.id)
     let dto: TrimDefaultOptionDTO = try await
     trimSelectionRequestManager.perform(request)
     return try dto.toDomain(trim: trim)
   }
 
-  func fetchMinMaxPriceByTrim(in trimId: Int) async throws -> (CLNumber, CLNumber) {
+  func fetchMinMaxPriceByTrim(of trimId: Int) async throws -> (CLNumber, CLNumber) {
     let request = TrimSelectionRequest.fetchTrimMaxMinPrice(trimId: trimId)
     let dto: MaxMinPriceDTO = try await trimSelectionRequestManager.perform(request)
     return try dto.toDomain()

--- a/iOS/Catalog/Catalog/TrimSelection/Intent/TrimSelectionIntent.swift
+++ b/iOS/Catalog/Catalog/TrimSelection/Intent/TrimSelectionIntent.swift
@@ -47,7 +47,7 @@ extension TrimSelectionIntent: TrimSelectionIntentType, IntentType {
       case .enteredTrimPage:
         Task {
           do {
-            let trims = try await repository.fetchTrims(in: state.carId)
+            let trims = try await repository.fetchTrims(of: state.carId)
             self.send(action: .fetchTrims(trims: trims))
           } catch let error {
             state.error = error as? TrimSelectionError
@@ -70,8 +70,8 @@ extension TrimSelectionIntent: TrimSelectionIntentType, IntentType {
         quotation.send(action: .isTrimChanged(trim: trim))
         Task {
           do {
-            let defaultQuotation = try await repository.fetchDefaultOptionsByTrim(in: trim)
-            let (maxPrice, minPrice) = try await repository.fetchMinMaxPriceByTrim(in: trim.id)
+            let defaultQuotation = try await repository.fetchDefaultOptionsByTrim(of: trim)
+            let (maxPrice, minPrice) = try await repository.fetchMinMaxPriceByTrim(of: trim.id)
             quotation.send(action: .isTrimSelected(defaultCarQuotation: defaultQuotation,
                                                    minPrice: minPrice,
                                                    maxPrice: maxPrice))

--- a/iOS/Catalog/Catalog/TrimSelection/View/TrimCardView.swift
+++ b/iOS/Catalog/Catalog/TrimSelection/View/TrimCardView.swift
@@ -32,7 +32,7 @@ struct TrimCardView: View {
           Spacer()
           Image("trim_select_image")
             .resizable()
-            .frame(width: 263, height: 197)
+            .frame(width: 263)
         }
 
         HMGDataCard(options: trim.hmgData)


### PR DESCRIPTION
# :eyes: What is this PR?
1. 견적 완료 페이지 외장, 내장 색상 나타내는 화면 구현하기
2. 예산 설정 플로팅 뷰 State에  status (default, 견적완료 페이지, 유사견적 페이지) 추가
3. 앱 사용자 플로우 개선
# :pencil: Changes
1. 견적 완료 페이지 외장, 내장 색상 나타내는 화면 구현하기
- GeometryReader를 사용하여 내장 사진을 스크롤할 수 있는 뷰를 만들었습니다. 
- 사진을 중앙부터 스크롤 할 수 있도록 설정하는 것이 필요합니다. 
- `QuotationSheetTop`은 시트의 상단 부분이고 이 부분을 draggesture를 취하면 시트가 열리도록 하였습니다. 
* * *   
2. 예산 설정 플로팅 뷰 State에  status (default, 견적완료 페이지, 유사견적 페이지) 추가
- 네비게이션 index에 따라 예산 설정 플로팅 뷰의 스타일을 변경해줘야하기 때문에 예산 설정 State에 `status`를 추가하였습니다. 
- 플로팅 뷰 스타일 변경해주는 것을 navigationview에서 if문에 따라 따로 생성해주도록 했는데 navi -> budgetsetting 에 이벤틀르 쏴서 State기반으로 작동하게끔 바꿔줘야할 것 같습니다. 
* * *
 3. 앱 사용자 플로우 개선
 - 르블랑 선택 시 타입 선택 페이지로 전환하도록 설정 
 - 트림이 선택되었는 지 판단하는 로직을 추가하였지만 상단 네비바 이동을 막는 방법은 찾아야합니다. 
 -  탭 뷰 스크롤 이동 방지하였습니다 .
 - quotation 견적이 예산 설정 뷰와 하단 바에 적용되도록 하였습니다. 

Quotation 전역 State 사용에 대한 규칙을 정하면 좋을 것 같습니다. (상위에서 내려준다? intent에 놓는다? delegate?)

## :pushpin: Related issue(s)
#182 
## :camera: Attachment(optional)
<img src = "https://github.com/softeerbootcamp-2nd/H2-O/assets/110437548/3c4381e0-3100-4925-be0a-652f3b7cf0cc" width = "300">

<img src = "https://github.com/softeerbootcamp-2nd/H2-O/assets/110437548/238c8c16-fdc5-4dc5-9e40-80576e79ea88" width = "300">

<img src = "https://github.com/softeerbootcamp-2nd/H2-O/assets/110437548/a723e28f-0980-4a0c-a04e-009795aed4fe" width = "300">
