### PR TITLE
Feature/#210/유사 견적 정보 조회 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.1'
 	implementation 'mysql:mysql-connector-java:8.0.29'
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
+	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 	runtimeOnly 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -33,8 +35,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.1'
 	testImplementation group: 'com.h2database', name: 'h2', version: '2.2.220'
-	implementation 'io.springfox:springfox-boot-starter:3.0.0'
-	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'

--- a/backend/src/main/java/com/h2o/h2oServer/domain/model_type/dto/ModelTypeIdDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/model_type/dto/ModelTypeIdDto.java
@@ -1,7 +1,9 @@
 package com.h2o.h2oServer.domain.model_type.dto;
 
+import io.swagger.annotations.ApiModel;
 import lombok.Data;
 
+@ApiModel(value = "견적 저장 요청 - 모델 타입 id 정보")
 @Data
 public class ModelTypeIdDto {
     private Long powertrainId;

--- a/backend/src/main/java/com/h2o/h2oServer/domain/model_type/dto/ModelTypeNameDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/model_type/dto/ModelTypeNameDto.java
@@ -1,0 +1,22 @@
+package com.h2o.h2oServer.domain.model_type.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ModelTypeNameDto {
+    private String powertrainName;
+    private String bodytypeName;
+    private String drivetrainName;
+
+    public static ModelTypeNameDto of(String powertrainName,
+                                      String bodytypeName,
+                                      String drivetrainName) {
+        return ModelTypeNameDto.builder()
+                .powertrainName(powertrainName)
+                .bodytypeName(bodytypeName)
+                .drivetrainName(drivetrainName)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/model_type/dto/ModelTypeNameDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/model_type/dto/ModelTypeNameDto.java
@@ -1,8 +1,10 @@
 package com.h2o.h2oServer.domain.model_type.dto;
 
+import io.swagger.annotations.ApiModel;
 import lombok.Builder;
 import lombok.Data;
 
+@ApiModel(value = "유사 견적 정보 조회 응답 - 모델 타입 정보")
 @Data
 @Builder
 public class ModelTypeNameDto {

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionSummaryDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionSummaryDto.java
@@ -1,0 +1,25 @@
+package com.h2o.h2oServer.domain.option.dto;
+
+import com.h2o.h2oServer.domain.option.entity.OptionDetailsEntity;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OptionSummaryDto {
+    private Long id;
+    private String name;
+    private String category;
+    private String image;
+    private Integer price;
+
+    public static OptionSummaryDto of(Long id, OptionDetailsEntity optionEntity) {
+        return OptionSummaryDto.builder()
+                .id(id)
+                .name(optionEntity.getName())
+                .image(optionEntity.getImage())
+                .category(optionEntity.getCategory().getLabel())
+                .price(optionEntity.getPrice())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionSummaryDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/dto/OptionSummaryDto.java
@@ -1,9 +1,11 @@
 package com.h2o.h2oServer.domain.option.dto;
 
 import com.h2o.h2oServer.domain.option.entity.OptionDetailsEntity;
+import io.swagger.annotations.ApiModel;
 import lombok.Builder;
 import lombok.Data;
 
+@ApiModel(value = "유사 견적 정보 조회 응답 - 옵션 정보")
 @Data
 @Builder
 public class OptionSummaryDto {

--- a/backend/src/main/java/com/h2o/h2oServer/domain/options/mapper/OptionsMapper.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/options/mapper/OptionsMapper.java
@@ -10,8 +10,12 @@ import java.util.List;
 @Mapper
 public interface OptionsMapper {
     List<TrimExtraOptionEntity> findTrimPackages(Long trimId);
+
     List<TrimExtraOptionEntity> findTrimExtraOptions(Long trimId);
+
     List<TrimDefaultOptionEntity> findTrimDefaultOptions(Long trimId);
+
     List<HashTagEntity> findPackageHashTags(Long packageId);
+
     List<HashTagEntity> findOptionHashTag(Long optionId);
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/api/QuotationController.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/api/QuotationController.java
@@ -3,22 +3,30 @@ package com.h2o.h2oServer.domain.quotation.api;
 import com.h2o.h2oServer.domain.quotation.application.QuotationService;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationResponseDto;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationRequestDto;
+import com.h2o.h2oServer.domain.quotation.dto.SimilarQuotationDto;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
+@RequestMapping("/quotation")
 @RequiredArgsConstructor
 public class QuotationController {
 
     private final QuotationService quotationService;
 
-    @PostMapping("/quotation")
+    @PostMapping
     public ResponseEntity<QuotationResponseDto> saveQuotation(@RequestBody QuotationRequestDto quotationRequestDto) {
         QuotationResponseDto quotationResponseDto = quotationService.saveQuotation(quotationRequestDto);
         return new ResponseEntity<>(quotationResponseDto, HttpStatus.CREATED);
+    }
+
+    @PostMapping("/similar")
+    public List<SimilarQuotationDto> getSimilarQuotations(@RequestBody QuotationRequestDto quotationRequestDto) {
+        return quotationService.findSimilarQuotations(quotationRequestDto);
     }
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/api/QuotationController.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/api/QuotationController.java
@@ -4,6 +4,9 @@ import com.h2o.h2oServer.domain.quotation.application.QuotationService;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationResponseDto;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationRequestDto;
 import com.h2o.h2oServer.domain.quotation.dto.SimilarQuotationDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,16 +18,21 @@ import java.util.List;
 @RestController
 @RequestMapping("/quotation")
 @RequiredArgsConstructor
+@Api(tags = "견적")
 public class QuotationController {
 
     private final QuotationService quotationService;
 
+    @ApiOperation(value = "견적 정보 저장", notes = "견적 정보를 저장하는 API")
+    @ApiImplicitParam(name = "quotationRequestDto", value = "저장할 견적 정보")
     @PostMapping
     public ResponseEntity<QuotationResponseDto> saveQuotation(@RequestBody QuotationRequestDto quotationRequestDto) {
         QuotationResponseDto quotationResponseDto = quotationService.saveQuotation(quotationRequestDto);
         return new ResponseEntity<>(quotationResponseDto, HttpStatus.CREATED);
     }
 
+    @ApiOperation(value = "유사 견적 조회", notes = "유사 견적 정보를 반환하는 API")
+    @ApiImplicitParam(name = "quotationRequestDto", value = "비교할 견적 정보")
     @PostMapping("/similar")
     public List<SimilarQuotationDto> getSimilarQuotations(@RequestBody QuotationRequestDto quotationRequestDto) {
         return quotationService.findSimilarQuotations(quotationRequestDto);

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/CosineSimilarityCalculator.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/CosineSimilarityCalculator.java
@@ -46,9 +46,4 @@ public class CosineSimilarityCalculator {
 
         return vector;
     }
-
-    public static void main(String[] args) {
-
-    }
-
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/CosineSimilarityCalculator.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/CosineSimilarityCalculator.java
@@ -1,0 +1,30 @@
+package com.h2o.h2oServer.domain.quotation.application;
+
+import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
+
+import java.util.Map;
+
+public class CosineSimilarityCalculator {
+    public static double calculateCosineSimilarity(Map<HashTag, Integer> vector1, Map<HashTag, Integer> vector2) {
+        double dotProduct = 0.0;
+        double norm1 = 0.0;
+        double norm2 = 0.0;
+
+        for (HashTag key : vector1.keySet()) {
+            if (vector2.containsKey(key)) {
+                dotProduct += vector1.get(key) * vector2.get(key);
+            }
+            norm1 += Math.pow(vector1.get(key), 2);
+        }
+
+        for (Integer value : vector2.values()) {
+            norm2 += Math.pow(value, 2);
+        }
+
+        if (norm1 == 0.0 || norm2 == 0.0) {
+            return 0.0;
+        }
+
+        return dotProduct / (Math.sqrt(norm1) * Math.sqrt(norm2));
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/CosineSimilarityCalculator.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/CosineSimilarityCalculator.java
@@ -19,9 +19,6 @@ public class CosineSimilarityCalculator {
             throw new IllegalArgumentException("두 벡터의 길이가 다릅니다.");
         }
 
-        System.out.println(Arrays.toString(vector1));
-        System.out.println(Arrays.toString(vector2));
-
         double dotProduct = 0.0;
         double norm1 = 0.0;
         double norm2 = 0.0;

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/CosineSimilarityCalculator.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/CosineSimilarityCalculator.java
@@ -2,23 +2,34 @@ package com.h2o.h2oServer.domain.quotation.application;
 
 import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 public class CosineSimilarityCalculator {
-    public static double calculateCosineSimilarity(Map<HashTag, Integer> vector1, Map<HashTag, Integer> vector2) {
+
+    private static final List<HashTag> hashTagIndex = List.of(HashTag.values());
+
+    public static double calculateCosineSimilarity(Map<HashTag, Integer> map1, Map<HashTag, Integer> map2) {
+        return calculateCosineSimilarity(toVector(map1), toVector(map2));
+    }
+
+    public static double calculateCosineSimilarity(int[] vector1, int[] vector2) {
+        if (vector1.length != vector2.length) {
+            throw new IllegalArgumentException("두 벡터의 길이가 다릅니다.");
+        }
+
+        System.out.println(Arrays.toString(vector1));
+        System.out.println(Arrays.toString(vector2));
+
         double dotProduct = 0.0;
         double norm1 = 0.0;
         double norm2 = 0.0;
 
-        for (HashTag key : vector1.keySet()) {
-            if (vector2.containsKey(key)) {
-                dotProduct += vector1.get(key) * vector2.get(key);
-            }
-            norm1 += Math.pow(vector1.get(key), 2);
-        }
-
-        for (Integer value : vector2.values()) {
-            norm2 += Math.pow(value, 2);
+        for (int i = 0; i < vector1.length; i++) {
+            dotProduct += vector1[i] * vector2[i];
+            norm1 += Math.pow(vector1[i], 2);
+            norm2 += Math.pow(vector2[i], 2);
         }
 
         if (norm1 == 0.0 || norm2 == 0.0) {
@@ -27,4 +38,20 @@ public class CosineSimilarityCalculator {
 
         return dotProduct / (Math.sqrt(norm1) * Math.sqrt(norm2));
     }
+
+    private static int[] toVector(Map<HashTag, Integer> map) {
+        int[] vector = new int[hashTagIndex.size()];
+
+
+        for (HashTag hashTag : map.keySet()) {
+            vector[hashTagIndex.indexOf(hashTag)] = map.get(hashTag);
+        }
+
+        return vector;
+    }
+
+    public static void main(String[] args) {
+
+    }
+
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/QuotationService.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/QuotationService.java
@@ -42,8 +42,8 @@ import static com.h2o.h2oServer.global.util.StringParser.*;
 public class QuotationService {
     public static final double SIMILARITY_LOWER_BOUND = 0.2;
     public static final double SIMILARITY_UPPER_BOUND = 0.9;
-    private final QuotationMapper quotationMapper;
 
+    private final QuotationMapper quotationMapper;
     private final CarMapper carMapper;
     private final TrimMapper trimMapper;
     private final PowertrainMapper powertrainMapper;

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/QuotationService.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/QuotationService.java
@@ -3,12 +3,17 @@ package com.h2o.h2oServer.domain.quotation.application;
 import com.h2o.h2oServer.domain.car.exception.NoSuchCarException;
 import com.h2o.h2oServer.domain.car.mapper.CarMapper;
 import com.h2o.h2oServer.domain.model_type.dto.ModelTypeIdDto;
+import com.h2o.h2oServer.domain.model_type.dto.ModelTypeNameDto;
 import com.h2o.h2oServer.domain.model_type.exception.NoSuchBodyTypeException;
 import com.h2o.h2oServer.domain.model_type.exception.NoSuchDriveTrainException;
 import com.h2o.h2oServer.domain.model_type.exception.NoSuchPowertrainException;
 import com.h2o.h2oServer.domain.model_type.mapper.BodytypeMapper;
 import com.h2o.h2oServer.domain.model_type.mapper.DrivetrainMapper;
 import com.h2o.h2oServer.domain.model_type.mapper.PowertrainMapper;
+import com.h2o.h2oServer.domain.option.dto.OptionSummaryDto;
+import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
+import com.h2o.h2oServer.domain.option.entity.OptionDetailsEntity;
+import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
 import com.h2o.h2oServer.domain.option.exception.NoSuchOptionException;
 import com.h2o.h2oServer.domain.option.mapper.OptionMapper;
 import com.h2o.h2oServer.domain.optionPackage.exception.NoSuchPackageException;
@@ -16,22 +21,26 @@ import com.h2o.h2oServer.domain.optionPackage.mapper.PackageMapper;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationRequestDto;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationResponseDto;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationDto;
+import com.h2o.h2oServer.domain.quotation.dto.SimilarQuotationDto;
 import com.h2o.h2oServer.domain.quotation.entity.OptionQuotationEntity;
 import com.h2o.h2oServer.domain.quotation.entity.PackageQuotationEntity;
+import com.h2o.h2oServer.domain.quotation.entity.ReleaseEntity;
 import com.h2o.h2oServer.domain.quotation.mapper.QuotationMapper;
 import com.h2o.h2oServer.domain.trim.Exception.NoSuchTrimException;
+import com.h2o.h2oServer.domain.trim.mapper.ExternalColorMapper;
 import com.h2o.h2oServer.domain.trim.mapper.TrimMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class QuotationService {
-
     private final QuotationMapper quotationMapper;
+
     private final CarMapper carMapper;
     private final TrimMapper trimMapper;
     private final PowertrainMapper powertrainMapper;
@@ -39,6 +48,119 @@ public class QuotationService {
     private final DrivetrainMapper drivetrainMapper;
     private final OptionMapper optionMapper;
     private final PackageMapper packageMapper;
+    private final ExternalColorMapper externalColorMapper;
+
+    public List<SimilarQuotationDto> findSimilarQuotations(QuotationRequestDto quotationRequestDto) {
+
+
+        Map<HashTag, Integer> requestHashTagCount = new HashMap<>();
+
+        quotationRequestDto.getOptionIds().forEach((optionId) -> {
+            List<HashTagEntity> hashTagEntities = optionMapper.findHashTag(optionId);
+
+            for (HashTagEntity hashTagEntity : hashTagEntities) {
+                HashTag hashTag = hashTagEntity.getName();
+                requestHashTagCount.put(hashTag, requestHashTagCount.getOrDefault(hashTag, 0) + 1);
+            }
+        });
+
+        quotationRequestDto.getPackageIds().forEach((packageId) -> {
+            List<HashTagEntity> hashTagEntities = packageMapper.findHashTag(packageId);
+
+            for (HashTagEntity hashTagEntity : hashTagEntities) {
+                HashTag hashTag = hashTagEntity.getName();
+                requestHashTagCount.put(hashTag, requestHashTagCount.getOrDefault(hashTag, 0) + 1);
+            }
+        });
+
+        List<ReleaseEntity> releaseEntities = quotationMapper.findReleaseQuotationWithVolume(quotationRequestDto.getTrimId());
+        PriorityQueue<Map.Entry<ReleaseEntity, Double>> similarityQueue = new PriorityQueue<>(
+                (entry1, entry2) -> (-1) * Double.compare(entry1.getValue(), entry2.getValue())
+        );
+
+        for (int index = 0; index < releaseEntities.size(); index++) {
+            ReleaseEntity releaseEntity = releaseEntities.get(index);
+
+            List<Long> optionIds = Arrays.stream(releaseEntity.getOptionCombination()
+                            .split(","))
+                            .map(Long::parseLong)
+                            .collect(Collectors.toList());
+            List<Long> packageIds = Arrays.stream(releaseEntity.getPackageCombination()
+                            .split(","))
+                            .map(Long::parseLong)
+                            .collect(Collectors.toList());
+
+            Map<HashTag, Integer> hashTagCount = new HashMap<>();
+
+            optionIds.forEach((optionId) -> {
+                List<HashTagEntity> hashTagEntities = optionMapper.findHashTag(optionId);
+
+                for (HashTagEntity hashTagEntity : hashTagEntities) {
+                    HashTag hashTag = hashTagEntity.getName();
+                    hashTagCount.put(hashTag, hashTagCount.getOrDefault(hashTag, 0) + 1);
+                }
+            });
+
+            packageIds.forEach((packageId) -> {
+                List<HashTagEntity> hashTagEntities = packageMapper.findHashTag(packageId);
+
+                for (HashTagEntity hashTagEntity : hashTagEntities) {
+                    HashTag hashTag = hashTagEntity.getName();
+                    hashTagCount.put(hashTag, hashTagCount.getOrDefault(hashTag, 0) + 1);
+                }
+            });
+
+            double similarity = CosineSimilarityCalculator.calculateCosineSimilarity(requestHashTagCount, hashTagCount);
+
+            if (similarity < 0.2 || similarity > 0.9) {
+                continue;
+            }
+
+            similarityQueue.add(Map.entry(releaseEntity, similarity));
+        }
+
+        List<SimilarQuotationDto> similarQuotationDtos = new ArrayList<>();
+
+        for (int index = 0; index < 4; index++) {
+            ReleaseEntity releaseEntity = similarityQueue.poll().getKey();
+
+            String powertrainName = powertrainMapper.findById(releaseEntity.getPowertrainId()).getName();
+            String bodytypeName = bodytypeMapper.findById(releaseEntity.getBodytypeId()).getName();
+            String drivetrainName = drivetrainMapper.findById(releaseEntity.getDrivetrainId()).getName();
+            String image = externalColorMapper.findImages(releaseEntity.getExternalColorId()).get(30).getImage();
+            int price = releaseEntity.getPrice();
+
+            List<Long> optionIds = Arrays.stream(releaseEntity.getOptionCombination()
+                            .split(","))
+                            .map(Long::parseLong)
+                            .collect(Collectors.toList());
+            List<OptionSummaryDto> optionSummaryDtos = new ArrayList<>();
+
+            for (Long optionId : optionIds) {
+                if (quotationRequestDto.getOptionIds().contains(optionId)) {
+                    continue;
+                }
+                OptionDetailsEntity optionDetailsEntity = optionMapper.findOptionDetails(optionId, releaseEntity.getTrimId());
+                optionSummaryDtos.add(OptionSummaryDto.of(optionId, optionDetailsEntity));
+
+                if (optionSummaryDtos.size() > 1) break;
+            }
+
+            similarQuotationDtos.add(SimilarQuotationDto.of(
+                    ModelTypeNameDto.builder()
+                            .bodytypeName(bodytypeName)
+                            .drivetrainName(drivetrainName)
+                            .powertrainName(powertrainName)
+                            .build(),
+                    image,
+                    price,
+                    optionSummaryDtos
+            ));
+        }
+
+        return similarQuotationDtos;
+
+    }
 
     @Transactional
     public QuotationResponseDto saveQuotation(QuotationRequestDto quotationRequestDto) {
@@ -68,7 +190,7 @@ public class QuotationService {
         if (!bodytypeMapper.checkIfBodytypeExists(modelTypeIdDto.getBodytypeId())) {
             throw new NoSuchBodyTypeException();
         }
-        if (!drivetrainMapper.checkIfDrivetrainExists(modelTypeIdDto.getDrivetrainId())){
+        if (!drivetrainMapper.checkIfDrivetrainExists(modelTypeIdDto.getDrivetrainId())) {
             throw new NoSuchDriveTrainException();
         }
     }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/QuotationService.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/QuotationService.java
@@ -42,6 +42,7 @@ import static com.h2o.h2oServer.global.util.StringParser.*;
 public class QuotationService {
     public static final double SIMILARITY_LOWER_BOUND = 0.2;
     public static final double SIMILARITY_UPPER_BOUND = 0.9;
+    public static final int SIDE_IMAGE_INDEX = 12;
 
     private final QuotationMapper quotationMapper;
     private final CarMapper carMapper;
@@ -101,7 +102,7 @@ public class QuotationService {
             String powertrainName = powertrainMapper.findById(releaseEntity.getPowertrainId()).getName();
             String bodytypeName = bodytypeMapper.findById(releaseEntity.getBodytypeId()).getName();
             String drivetrainName = drivetrainMapper.findById(releaseEntity.getDrivetrainId()).getName();
-            String image = externalColorMapper.findImages(releaseEntity.getExternalColorId()).get(30).getImage();
+            String image = externalColorMapper.findImages(releaseEntity.getExternalColorId()).get(SIDE_IMAGE_INDEX).getImage();
             int price = releaseEntity.getPrice();
 
             List<OptionSummaryDto> optionSummaryDtos = extractOptionSummary(quotationRequestDto, releaseEntity);

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/dto/QuotationRequestDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/dto/QuotationRequestDto.java
@@ -1,10 +1,12 @@
 package com.h2o.h2oServer.domain.quotation.dto;
 
 import com.h2o.h2oServer.domain.model_type.dto.ModelTypeIdDto;
+import io.swagger.annotations.ApiModel;
 import lombok.Data;
 
 import java.util.List;
 
+@ApiModel(value = "견적 저장 요청")
 @Data
 public class QuotationRequestDto {
     private Long carId;

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/dto/QuotationResponseDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/dto/QuotationResponseDto.java
@@ -1,7 +1,9 @@
 package com.h2o.h2oServer.domain.quotation.dto;
 
+import io.swagger.annotations.ApiModel;
 import lombok.Data;
 
+@ApiModel(value = "견적 저장 요청 응답")
 @Data
 public class QuotationResponseDto {
     private Long quotationId;

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/dto/SimilarQuotationDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/dto/SimilarQuotationDto.java
@@ -1,0 +1,29 @@
+package com.h2o.h2oServer.domain.quotation.dto;
+
+import com.h2o.h2oServer.domain.model_type.dto.ModelTypeNameDto;
+import com.h2o.h2oServer.domain.option.dto.OptionSummaryDto;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class SimilarQuotationDto {
+    private ModelTypeNameDto modelType;
+    private String image;
+    private Integer price;
+    private List<OptionSummaryDto> options;
+
+    public static SimilarQuotationDto of(ModelTypeNameDto modelTypeNameDto,
+                                         String image,
+                                         Integer price,
+                                         List<OptionSummaryDto> options) {
+        return SimilarQuotationDto.builder()
+                .modelType(modelTypeNameDto)
+                .image(image)
+                .price(price)
+                .options(options)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/dto/SimilarQuotationDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/dto/SimilarQuotationDto.java
@@ -2,11 +2,13 @@ package com.h2o.h2oServer.domain.quotation.dto;
 
 import com.h2o.h2oServer.domain.model_type.dto.ModelTypeNameDto;
 import com.h2o.h2oServer.domain.option.dto.OptionSummaryDto;
+import io.swagger.annotations.ApiModel;
 import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
 
+@ApiModel(value = "유사 견적 정보 조회 응답")
 @Data
 @Builder
 public class SimilarQuotationDto {

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/entity/ReleaseEntity.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/entity/ReleaseEntity.java
@@ -1,0 +1,22 @@
+package com.h2o.h2oServer.domain.quotation.entity;
+
+import io.swagger.models.auth.In;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@Builder
+@EqualsAndHashCode
+public class ReleaseEntity {
+    private Long trimId;
+    private Long powertrainId;
+    private Long bodytypeId;
+    private Long drivetrainId;
+    private Long internalColorId;
+    private Long externalColorId;
+    private String optionCombination;
+    private String packageCombination;
+    private Integer price;
+    private Integer quotationCount;
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/entity/ReleaseEntity.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/entity/ReleaseEntity.java
@@ -1,13 +1,14 @@
 package com.h2o.h2oServer.domain.quotation.entity;
 
-import io.swagger.models.auth.In;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
 @EqualsAndHashCode
+@ToString
 public class ReleaseEntity {
     private Long trimId;
     private Long powertrainId;

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/mapper/QuotationMapper.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/mapper/QuotationMapper.java
@@ -4,14 +4,24 @@ import com.h2o.h2oServer.domain.quotation.dto.QuotationDto;
 import com.h2o.h2oServer.domain.quotation.entity.OptionQuotationEntity;
 import com.h2o.h2oServer.domain.quotation.entity.PackageQuotationEntity;
 
+import com.h2o.h2oServer.domain.quotation.entity.ReleaseEntity;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 @Mapper
 public interface QuotationMapper {
     void saveQuotation(QuotationDto quotationDTO);
+
     void saveOptionQuotation(OptionQuotationEntity optionQuotationEntity);
+
     void savePackageQuotation(PackageQuotationEntity packageQuotationEntity);
+
     long countQuotation();
+
     long countOptionQuotation();
+
     long countPackageQuotation();
+
+    List<ReleaseEntity> findReleaseQuotationWithVolume(Long trimId);
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/application/TrimService.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/application/TrimService.java
@@ -122,7 +122,6 @@ public class TrimService {
         }
     }
 
-
     public PriceDistributionDto findAndScalePriceDistribution(Long trimId) {
         PriceRangeDto priceRangeDto = findPriceRange(trimId);
         Integer minPrice = priceRangeDto.getMinPrice();

--- a/backend/src/main/java/com/h2o/h2oServer/global/util/StringParser.java
+++ b/backend/src/main/java/com/h2o/h2oServer/global/util/StringParser.java
@@ -1,0 +1,13 @@
+package com.h2o.h2oServer.global.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StringParser {
+    public static List<Long> parseToLongList(String string) {
+        return Arrays.stream(string.split(","))
+                .map(Long::parseLong)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/resources/static/mapper/quotation/quotation_mapper.xml
+++ b/backend/src/main/resources/static/mapper/quotation/quotation_mapper.xml
@@ -67,7 +67,8 @@
                            price,
                            GROUP_CONCAT(o.option_id ORDER BY o.option_id ASC) AS option_combination
                     from sold_car
-                             join sold_car_extra_options as o on (sold_car.trim_id = #{trimId} and sold_car.id = o.sold_car_id)
+                             join sold_car_extra_options as o
+                                  on (sold_car.trim_id = #{trimId} and sold_car.id = o.sold_car_id)
                     group by id) as option_concatted
                        join sold_car_package as p on (option_concatted.id = p.sold_car_id)
               group by id) as all_concatted

--- a/backend/src/main/resources/static/mapper/quotation/quotation_mapper.xml
+++ b/backend/src/main/resources/static/mapper/quotation/quotation_mapper.xml
@@ -35,4 +35,43 @@
     <select id="countPackageQuotation" resultType="long">
         select count(*) from package_quotation;
     </select>
+
+    <select id="findReleaseQuotationWithVolume" resultType="ReleaseEntity">
+        select trim_id,
+               powertrain_id,
+               bodytype_id,
+               drivetrain_id,
+               internal_color_id,
+               external_color_id,
+               option_combination,
+               package_combination,
+               price,
+               count(*) as quotation_count
+        from (select id,
+                     trim_id,
+                     powertrain_id,
+                     bodytype_id,
+                     drivetrain_id,
+                     internal_color_id,
+                     external_color_id,
+                     price,
+                     option_combination,
+                     GROUP_CONCAT(p.package_id ORDER BY p.package_id ASC) AS package_combination
+              from (select id,
+                           trim_id,
+                           powertrain_id,
+                           bodytype_id,
+                           drivetrain_id,
+                           internal_color_id,
+                           external_color_id,
+                           price,
+                           GROUP_CONCAT(o.option_id ORDER BY o.option_id ASC) AS option_combination
+                    from sold_car
+                             join sold_car_extra_options as o on (sold_car.trim_id = #{trimId} and sold_car.id = o.sold_car_id)
+                    group by id) as option_concatted
+                       join sold_car_package as p on (option_concatted.id = p.sold_car_id)
+              group by id) as all_concatted
+        group by trim_id, powertrain_id, bodytype_id, drivetrain_id, internal_color_id, external_color_id, price,
+                 option_combination, package_combination;
+    </select>
 </mapper>

--- a/backend/src/test/java/com/h2o/h2oServer/domain/quotation/application/CosineSimilarityCalculatorTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/quotation/application/CosineSimilarityCalculatorTest.java
@@ -1,0 +1,60 @@
+package com.h2o.h2oServer.domain.quotation.application;
+
+import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+class CosineSimilarityCalculatorTest {
+
+    @Test
+    @DisplayName("해시태그 벡터의 코사인 유사도를 반환한다.")
+    void testCalculateCosineSimilarity() {
+        //given
+        Map<HashTag, Integer> vector1 = new HashMap<>();
+        vector1.put(HashTag.CAMPING, 3);
+        vector1.put(HashTag.BEGINNER_DRIVING, 1);
+        vector1.put(HashTag.CHILDREN, 2);
+
+        Map<HashTag, Integer> vector2 = new HashMap<>();
+        vector2.put(HashTag.CAMPING, 2);
+        vector2.put(HashTag.BEGINNER_DRIVING, 2);
+        vector2.put(HashTag.CHILDREN, 1);
+
+        double expectedSimilarity = 0.8908708063747479;
+
+        //when
+        double similarity = CosineSimilarityCalculator.calculateCosineSimilarity(vector1, vector2);
+
+        //then
+        assertThat(similarity).isCloseTo(expectedSimilarity, offset(0.01));
+    }
+
+    @Test
+    @DisplayName("해시태그 벡터의 코사인 유사도를 반환한다. - 1인 경우")
+    void testCalculateCosineSimilarityWithOneValues() {
+        //given
+        Map<HashTag, Integer> vector1 = new HashMap<>();
+        vector1.put(HashTag.CAMPING, 1);
+        vector1.put(HashTag.BEGINNER_DRIVING, 1);
+        vector1.put(HashTag.CHILDREN, 1);
+
+        Map<HashTag, Integer> vector2 = new HashMap<>();
+        vector2.put(HashTag.CAMPING, 1);
+        vector2.put(HashTag.BEGINNER_DRIVING, 1);
+        vector2.put(HashTag.CHILDREN, 1);
+
+        double expectedSimilarity = 1.0;
+
+        //when
+        double similarity = CosineSimilarityCalculator.calculateCosineSimilarity(vector1, vector2);
+
+        //then
+        assertThat(similarity).isCloseTo(expectedSimilarity, offset(0.01));
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/quotation/application/QuotationServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/quotation/application/QuotationServiceTest.java
@@ -14,15 +14,14 @@ import com.h2o.h2oServer.domain.option.mapper.OptionMapper;
 import com.h2o.h2oServer.domain.optionPackage.exception.NoSuchPackageException;
 import com.h2o.h2oServer.domain.optionPackage.mapper.PackageMapper;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationRequestDto;
-import com.h2o.h2oServer.domain.quotation.dto.QuotationResponseDto;
 import com.h2o.h2oServer.domain.quotation.mapper.QuotationMapper;
 import com.h2o.h2oServer.domain.trim.Exception.NoSuchTrimException;
+import com.h2o.h2oServer.domain.trim.mapper.ExternalColorMapper;
 import com.h2o.h2oServer.domain.trim.mapper.TrimMapper;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
-import org.springframework.test.context.jdbc.Sql;
 
 import java.util.List;
 
@@ -41,6 +40,7 @@ class QuotationServiceTest {
     private static OptionMapper optionMapper;
     private static PackageMapper packageMapper;
     private static QuotationService quotationService;
+    private static ExternalColorMapper externalColorMapper;
     private static SoftAssertions softly;
 
     @BeforeAll
@@ -53,6 +53,7 @@ class QuotationServiceTest {
         drivetrainMapper = Mockito.mock(DrivetrainMapper.class);
         optionMapper = Mockito.mock(OptionMapper.class);
         packageMapper = Mockito.mock(PackageMapper.class);
+        externalColorMapper = Mockito.mock(ExternalColorMapper.class);
         quotationService = new QuotationService(quotationMapper,
                 carMapper,
                 trimMapper,
@@ -60,7 +61,8 @@ class QuotationServiceTest {
                 bodytypeMapper,
                 drivetrainMapper,
                 optionMapper,
-                packageMapper);
+                packageMapper,
+                externalColorMapper);
         softly = new SoftAssertions();
     }
 

--- a/backend/src/test/java/com/h2o/h2oServer/domain/quotation/mapper/QuotationMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/quotation/mapper/QuotationMapperTest.java
@@ -5,14 +5,18 @@ import com.h2o.h2oServer.domain.quotation.dto.QuotationDto;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationRequestDto;
 import com.h2o.h2oServer.domain.quotation.entity.OptionQuotationEntity;
 import com.h2o.h2oServer.domain.quotation.entity.PackageQuotationEntity;
+import com.h2o.h2oServer.domain.quotation.entity.ReleaseEntity;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @MybatisTest
 class QuotationMapperTest {
@@ -96,5 +100,43 @@ class QuotationMapperTest {
         request.setPackageIds(List.of(11L));
 
         return request;
+    }
+    
+    @Test
+    @DisplayName("동일한 출고 견적의 데이터와 갯수 정보를 반환한다.")
+    @Sql("classpath:db/quotation/release-data.sql")
+    void findReleaseQuotationWithVolume() {
+        //given
+        long trimId = 2L;
+        ReleaseEntity expectedReleaseEntity = ReleaseEntity.builder()
+                .powertrainId(2L)
+                .bodytypeId(2L)
+                .drivetrainId(2L)
+                .internalColorId(2L)
+                .externalColorId(2L)
+                .price(35000)
+                .trimId(2L)
+                .quotationCount(2)
+                .optionCombination("1,4")
+                .packageCombination("3")
+                .build();
+        ReleaseEntity expectedReleaseEntity2 = ReleaseEntity.builder()
+                .powertrainId(1L)
+                .bodytypeId(1L)
+                .drivetrainId(1L)
+                .internalColorId(1L)
+                .externalColorId(1L)
+                .price(30000)
+                .trimId(2L)
+                .quotationCount(1)
+                .optionCombination("1")
+                .packageCombination("1,2")
+                .build();
+        //when
+        List<ReleaseEntity> actualReleaseEntities = quotationMapper.findReleaseQuotationWithVolume(trimId);
+
+        //then
+        assertThat(actualReleaseEntities).contains(expectedReleaseEntity)
+                .contains(expectedReleaseEntity2);
     }
 }

--- a/backend/src/test/resources/db/quotation/release-data.sql
+++ b/backend/src/test/resources/db/quotation/release-data.sql
@@ -1,0 +1,22 @@
+INSERT INTO sold_car (id, car_id, trim_id, powertrain_id, bodytype_id, drivetrain_id, internal_color_id, external_color_id, price)
+VALUES
+    (1, 1, 2, 1, 1, 1, 1, 1, 30000),
+    (2, 1, 2, 2, 2, 2, 2, 2, 35000),
+    (3, 1, 2, 2, 2, 2, 2, 2, 35000);
+
+-- Inserting data into sold_car_extra_options table
+INSERT INTO sold_car_extra_options (sold_car_id, option_id)
+VALUES
+    (1, 1),
+    (3, 1),
+    (3, 4),
+    (2, 1),
+    (2, 4);
+
+-- Inserting data into sold_car_package table
+INSERT INTO sold_car_package (sold_car_id, package_id)
+VALUES
+    (1, 1),
+    (1, 2),
+    (2, 3),
+    (3, 3);


### PR DESCRIPTION
# :eyes: What is this PR?
유사 견적 정보 조회 API 구현
# :pencil: Changes
- 견적관련 API, dto에 스웨거 달았습니다.
- 코사인 유사도 계산하는 모듈 따로 빼서, QuotationService에서 사용하도록 했습니다. 그 외에 유사 견적 데이터 가져오는 데 필요한 기능들은 QuotationService에서 private method로 분리한 정도입니다. 로직이 너무 복잡해서 어떻게 더 깔끔하게 분리해야할 지 고민입니다. 
- 로직 이해하기 힘들 것 같아서 자존심 상하지만 주석 많이 달아놨습니다..
- Option, Options 도메인 분리되어있는게 아주 불편한데... 이거 합치는 것도 대공사일 것 같네요
- 기획서 상에서 유사견적에서 보여주는 이미지(옆으로 서있는 차 사진)가 외장 색상 이미지 리스트의 12번째 인덱스가 인 것 같아서 우선 상수로 빼서 열 두번 째 사진 가져오도록 짰습니다.
- 유사 견적의 정보를 모두 보여주는 것이 아니라 최대 두 개까지 다른 옵션을 보여주는 건데, 어떤 기준으로 선택할 지 몰라서 optionId 기준으로 가져오도록 했습니다. 패키지는 제외했습니다.
- 패키지와 옵션은 공통된 특징이 많음에도 불구하고 아예 다른 도메인으로 분류해서 비슷하고 중복된 코드가 많아지는 것 같습니다..... 추상화하는 등의 방법으로 이것을 해결할 방법에 대해 생각해보면 좋을 것 같은데 당장 해야할 일은 아닌 것 같네요 암튼 그럿습니다
- QuotationService의 유사 견적 반환하는 메소드 테스트 코드는 조금 짜보다가 실패했습니다.. 너무 복잡하고 묵직해서 단위테스트 같지가 않네요 
- api 응답은 첫 요청은 약 2.4초, 두 번째부터는 2초 정도 걸리는 것 같습니다. mybatis 자체 쿼리 캐싱 때문인 것 같은데, redis로 메소드 결과, api 결과도 캐싱할 필요 있어 보입니다. 

## :pushpin: Related issue(s)
closes #210 
## :camera: Attachment(optional)
<img width="1392" alt="스크린샷 2023-08-19 오후 6 11 37" src="https://github.com/softeerbootcamp-2nd/H2-O/assets/91039622/dac0076c-08cf-46f6-9868-b23feac7d571">
