### PR TITLE
Feature/#221/테스트 코드 개선/리팩토링

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,21 +26,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.1'
 	implementation 'mysql:mysql-connector-java:8.0.29'
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
+	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+	implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
 	runtimeOnly 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.assertj:assertj-core:3.11.1'
+	testImplementation 'org.mockito:mockito-core:4.8.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.1'
 	testImplementation group: 'com.h2database', name: 'h2', version: '2.2.220'
-	implementation 'io.springfox:springfox-boot-starter:3.0.0'
-	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
-
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-	testImplementation 'org.assertj:assertj-core:3.16.1'
-	testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.2"
-	testImplementation 'org.mockito:mockito-core:4.8.0'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/h2o/h2oServer/domain/model_type/application/ModelTypeService.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/model_type/application/ModelTypeService.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class ModelTypeService {
-
     private final PowertrainMapper powerTrainMapper;
     private final BodytypeMapper bodyTypeMapper;
     private final DrivetrainMapper driveTrainMapper;
@@ -42,7 +41,16 @@ public class ModelTypeService {
         Long powertrainId = powertrain.getPowertrainId();
 
         PowertrainOutputEntity output = powerTrainMapper.findOutput(powertrainId);
+
+        if (output == null) {
+            throw new NoSuchCarException();
+        }
+
         PowertrainTorqueEntity torque = powerTrainMapper.findTorque(powertrainId);
+
+        if (torque == null) {
+            throw new NoSuchCarException();
+        }
 
         return CarPowertrainDto.of(powertrain, output, torque);
     }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/model_type/dto/ModelTypeIdDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/model_type/dto/ModelTypeIdDto.java
@@ -1,8 +1,10 @@
 package com.h2o.h2oServer.domain.model_type.dto;
 
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class ModelTypeIdDto {
     private Long powertrainId;
     private Long bodytypeId;

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/api/OptionController.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/api/OptionController.java
@@ -24,7 +24,7 @@ public class OptionController {
     })
     @GetMapping("/trim/{trimId}/option/{optionId}")
     public OptionDetailsDto getOptionInformation(@PathVariable Long trimId, @PathVariable Long optionId) {
-        OptionDetailsDto optionInformation = optionService.findOptionInformation(optionId, trimId);
+        OptionDetailsDto optionInformation = optionService.findDetailedOptionInformation(optionId, trimId);
         return optionInformation;
     }
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/option/application/OptionService.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/option/application/OptionService.java
@@ -18,7 +18,7 @@ public class OptionService {
 
     private final OptionMapper optionMapper;
 
-    public OptionDetailsDto findOptionInformation(Long optionId, Long trimId) {
+    public OptionDetailsDto findDetailedOptionInformation(Long optionId, Long trimId) {
         OptionDetailsEntity optionDetailsEntity = optionMapper.findOptionDetails(optionId, trimId);
 
         validateExistenceOfOption(optionDetailsEntity);

--- a/backend/src/main/java/com/h2o/h2oServer/domain/options/mapper/OptionsMapper.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/options/mapper/OptionsMapper.java
@@ -13,16 +13,25 @@ import java.util.List;
 @Mapper
 public interface OptionsMapper {
     List<TrimExtraOptionEntity> findTrimPackages(Long trimId);
+
     List<TrimExtraOptionEntity> findTrimPackagesWithRange(@Param("trimId") Long trimId,
                                                           @Param("pageRange") PageRangeDto pageRange);
+
     List<TrimExtraOptionEntity> findTrimExtraOptions(Long trimId);
+
     List<TrimExtraOptionEntity> findTrimExtraOptionsWithRange(@Param("trimId") Long trimId,
                                                               @Param("pageRange") PageRangeDto pageRange);
+
     List<TrimDefaultOptionEntity> findTrimDefaultOptions(Long trimId);
+
     List<TrimDefaultOptionEntity> findTrimDefaultOptionsWithRange(@Param("trimId") Long trimId,
                                                                   @Param("pageRange") PageRangeDto pageRange);
+
     List<HashTagEntity> findPackageHashTags(Long packageId);
+
     List<HashTagEntity> findOptionHashTag(Long optionId);
+
     Long findTrimPackageSize(Long trimId);
+
     Long findTrimOptionSize(@Param("trimId") Long trimId, @Param("optionType") OptionType optionType);
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/QuotationService.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/QuotationService.java
@@ -30,7 +30,6 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class QuotationService {
-
     private final QuotationMapper quotationMapper;
     private final CarMapper carMapper;
     private final TrimMapper trimMapper;
@@ -50,6 +49,31 @@ public class QuotationService {
         insertIntoPackageQuotation(quotationRequestDto.getPackageIds(), quotationId);
 
         return QuotationResponseDto.of(quotationId);
+    }
+
+    private void insertIntoOptionQuotation(List<Long> optionIds, Long quotationId) {
+        OptionQuotationEntity optionQuotationEntity = OptionQuotationEntity.builder()
+                .quotationId(quotationId)
+                .optionIds(optionIds)
+                .build();
+
+        quotationMapper.saveOptionQuotation(optionQuotationEntity);
+    }
+
+    private void insertIntoPackageQuotation(List<Long> packageIds, Long quotationId) {
+        PackageQuotationEntity packageQuotationEntity = PackageQuotationEntity.builder()
+                .quotationId(quotationId)
+                .packageIds(packageIds)
+                .build();
+
+        quotationMapper.savePackageQuotation(packageQuotationEntity);
+    }
+
+    private Long insertIntoQuotation(QuotationRequestDto quotationRequestDto) {
+        QuotationDto quotationDto = QuotationDto.of(quotationRequestDto);
+        quotationMapper.saveQuotation(quotationDto);
+
+        return quotationDto.getId();
     }
 
     private void validateQuotationRequest(QuotationRequestDto quotationRequestDto) {
@@ -93,7 +117,6 @@ public class QuotationService {
                     throw new NoSuchPackageException();
                 });
     }
-
     private void validateOptionExistence(QuotationRequestDto quotationRequestDto) {
         quotationRequestDto.getOptionIds().stream()
                 .filter(id -> !optionMapper.checkIfOptionExists(id))
@@ -103,28 +126,4 @@ public class QuotationService {
                 });
     }
 
-    private Long insertIntoQuotation(QuotationRequestDto quotationRequestDto) {
-        QuotationDto quotationDto = QuotationDto.of(quotationRequestDto);
-        quotationMapper.saveQuotation(quotationDto);
-
-        return quotationDto.getId();
-    }
-
-    private void insertIntoOptionQuotation(List<Long> optionIds, Long quotationId) {
-        OptionQuotationEntity optionQuotationEntity = OptionQuotationEntity.builder()
-                .quotationId(quotationId)
-                .optionIds(optionIds)
-                .build();
-
-        quotationMapper.saveOptionQuotation(optionQuotationEntity);
-    }
-
-    private void insertIntoPackageQuotation(List<Long> packageIds, Long quotationId) {
-        PackageQuotationEntity packageQuotationEntity = PackageQuotationEntity.builder()
-                .quotationId(quotationId)
-                .packageIds(packageIds)
-                .build();
-
-        quotationMapper.savePackageQuotation(packageQuotationEntity);
-    }
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/dto/QuotationRequestDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/dto/QuotationRequestDto.java
@@ -1,11 +1,13 @@
 package com.h2o.h2oServer.domain.quotation.dto;
 
 import com.h2o.h2oServer.domain.model_type.dto.ModelTypeIdDto;
+import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
+@Builder
 public class QuotationRequestDto {
     private Long carId;
     private Long trimId;

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/mapper/QuotationMapper.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/mapper/QuotationMapper.java
@@ -9,9 +9,14 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface QuotationMapper {
     void saveQuotation(QuotationDto quotationDTO);
+
     void saveOptionQuotation(OptionQuotationEntity optionQuotationEntity);
+
     void savePackageQuotation(PackageQuotationEntity packageQuotationEntity);
+
     long countQuotation();
+
     long countOptionQuotation();
+
     long countPackageQuotation();
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/model_type/BodyTypeFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/model_type/BodyTypeFixture.java
@@ -5,7 +5,7 @@ import com.h2o.h2oServer.domain.model_type.Entity.CarBodytypeEntity;
 
 import java.util.List;
 
-public class CarBodyTypeFixture {
+public class BodyTypeFixture {
 
     public static BodytypeEntity generateBodytypeEntity() {
         return BodytypeEntity.builder()

--- a/backend/src/test/java/com/h2o/h2oServer/domain/model_type/CarBodyTypeFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/model_type/CarBodyTypeFixture.java
@@ -1,0 +1,52 @@
+package com.h2o.h2oServer.domain.model_type;
+
+import com.h2o.h2oServer.domain.model_type.Entity.BodytypeEntity;
+import com.h2o.h2oServer.domain.model_type.Entity.CarBodytypeEntity;
+
+import java.util.List;
+
+public class CarBodyTypeFixture {
+
+    public static BodytypeEntity generateBodytypeEntity() {
+        return BodytypeEntity.builder()
+                .id(1L)
+                .name("name1")
+                .description("description1")
+                .image("img_url1")
+                .build();
+    }
+
+    public static CarBodytypeEntity generateCarBodyTypeEntity() {
+        return CarBodytypeEntity.builder()
+                .carId(1L)
+                .name("name1")
+                .description("description1")
+                .image("img_url1")
+                .bodytypeId(1L)
+                .price(10000)
+                .choiceRatio(0.11f)
+                .build();
+    }
+
+    public static List<CarBodytypeEntity> generateCarBodyTypeEntities() {
+        return List.of(CarBodytypeEntity.builder()
+                        .carId(1L)
+                        .name("name1")
+                        .description("description1")
+                        .image("img_url1")
+                        .bodytypeId(1L)
+                        .price(10000)
+                        .choiceRatio(0.11f)
+                        .build(),
+                CarBodytypeEntity.builder()
+                        .carId(1L)
+                        .name("name2")
+                        .description("description2")
+                        .image("img_url2")
+                        .bodytypeId(2L)
+                        .price(20000)
+                        .choiceRatio(0.21f)
+                        .build()
+        );
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/model_type/DrivetrainFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/model_type/DrivetrainFixture.java
@@ -1,0 +1,47 @@
+package com.h2o.h2oServer.domain.model_type;
+
+import com.h2o.h2oServer.domain.model_type.Entity.CarDrivetrainEntity;
+import com.h2o.h2oServer.domain.model_type.Entity.DrivetrainEntity;
+
+import java.util.List;
+
+public class DrivetrainFixture {
+    public static DrivetrainEntity generateDrivetrainEntity(Long drivetrainId) {
+        return DrivetrainEntity.builder()
+                .id(drivetrainId)
+                .name("name1")
+                .description("description1")
+                .image("img_url1")
+                .build();
+    }
+
+    public static DrivetrainEntity generateDrivetrainEntity() {
+        return generateDrivetrainEntity(1L);
+    }
+
+    public static List<CarDrivetrainEntity> generateCarDrivetrainEntities(Long carId) {
+        return List.of(
+                CarDrivetrainEntity.builder()
+                        .carId(carId)
+                        .name("name1")
+                        .description("description1")
+                        .image("img_url1")
+                        .drivetrainId(1L)
+                        .price(10000)
+                        .choiceRatio(0.22f)
+                        .build(),
+                CarDrivetrainEntity.builder()
+                        .carId(carId)
+                        .name("name2")
+                        .description("description2")
+                        .image("img_url2")
+                        .drivetrainId(2L)
+                        .price(20000)
+                        .choiceRatio(0.23f)
+                        .build());
+    }
+
+    public static List<CarDrivetrainEntity> generateCarDrivetrainEntities() {
+        return generateCarDrivetrainEntities(1L);
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/model_type/PowertrainFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/model_type/PowertrainFixture.java
@@ -1,0 +1,74 @@
+package com.h2o.h2oServer.domain.model_type;
+
+import com.h2o.h2oServer.domain.model_type.Entity.CarPowerTrainEntity;
+import com.h2o.h2oServer.domain.model_type.Entity.PowertrainEntity;
+import com.h2o.h2oServer.domain.model_type.Entity.PowertrainOutputEntity;
+import com.h2o.h2oServer.domain.model_type.Entity.PowertrainTorqueEntity;
+
+import java.util.List;
+
+public class PowertrainFixture {
+    public static PowertrainEntity generatePowertrainEntity(Long id) {
+        return PowertrainEntity.builder()
+                .id(id)
+                .name("powertrain1")
+                .description("description1")
+                .image("img_url1")
+                .build();
+    }
+
+    public static PowertrainEntity generatePowertrainEntity() {
+        return generatePowertrainEntity(1L);
+    }
+
+    public static List<CarPowerTrainEntity> generateCarPowerTrainEntities(Long carId) {
+        return List.of(CarPowerTrainEntity.builder()
+                        .carId(carId)
+                        .name("powertrain1")
+                        .description("description1")
+                        .image("img_url1")
+                        .powertrainId(1L)
+                        .price(100000)
+                        .choiceRatio(0.22f)
+                        .build(),
+                CarPowerTrainEntity.builder()
+                        .carId(carId)
+                        .name("powertrain2")
+                        .description("description2")
+                        .image("img_url2")
+                        .powertrainId(2L)
+                        .price(300000)
+                        .choiceRatio(0.21f)
+                        .build());
+    }
+
+    public static List<CarPowerTrainEntity> generateCarPowerTrainEntities() {
+        return generateCarPowerTrainEntities(1L);
+    }
+
+    public static PowertrainOutputEntity generatePowertrainOutputEntity(Long powertrainId) {
+        return PowertrainOutputEntity.builder()
+                .powertrainId(powertrainId)
+                .output(202.2f)
+                .minRpm(1000)
+                .maxRpm(1000)
+                .build();
+    }
+
+    public static PowertrainOutputEntity generatePowertrainOutputEntity() {
+        return generatePowertrainOutputEntity(1L);
+    }
+
+    public static PowertrainTorqueEntity generatePowertrainTorqueEntity(Long powertrainId) {
+        return PowertrainTorqueEntity.builder()
+                .powertrainId(powertrainId)
+                .torque(100.1f)
+                .minRpm(3000)
+                .maxRpm(3000)
+                .build();
+    }
+
+    public static PowertrainTorqueEntity generatePowertrainTorqueEntity() {
+        return generatePowertrainTorqueEntity(1L);
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/model_type/application/ModelTypeServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/model_type/application/ModelTypeServiceTest.java
@@ -1,5 +1,11 @@
 package com.h2o.h2oServer.domain.model_type.application;
 
+import com.h2o.h2oServer.domain.car.exception.NoSuchCarException;
+import com.h2o.h2oServer.domain.model_type.Entity.*;
+import com.h2o.h2oServer.domain.model_type.dto.CarBodytypeDto;
+import com.h2o.h2oServer.domain.model_type.dto.CarDrivetrainDto;
+import com.h2o.h2oServer.domain.model_type.dto.CarPowertrainDto;
+import com.h2o.h2oServer.domain.model_type.dto.ModelTypeDto;
 import com.h2o.h2oServer.domain.model_type.mapper.BodytypeMapper;
 import com.h2o.h2oServer.domain.model_type.mapper.DrivetrainMapper;
 import com.h2o.h2oServer.domain.model_type.mapper.PowertrainMapper;
@@ -8,10 +14,18 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.h2o.h2oServer.domain.model_type.DrivetrainFixture.*;
+import static com.h2o.h2oServer.domain.model_type.PowertrainFixture.*;
+import static com.h2o.h2oServer.domain.model_type.BodyTypeFixture.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
@@ -41,14 +55,87 @@ class ModelTypeServiceTest {
     void findModelTypes() {
         //given
         Long carId = 1L;
-        when(powerTrainMapper.findPowertrainsByCarId(carId)).thenReturn();
-        when(powerTrainMapper.findOutput(anyLong())).thenReturn();
-        when(powerTrainMapper.findTorque(anyLong())).thenReturn();
-        when(bodyTypeMapper.findBodytypesByCarId(carId)).thenReturn();
-        when(driveTrainMapper.findDrivetrainsByCarId(carId)).thenReturn();
+        when(powerTrainMapper.findPowertrainsByCarId(carId)).thenReturn(generateCarPowerTrainEntities());
+        when(powerTrainMapper.findOutput(anyLong())).thenReturn(generatePowertrainOutputEntity());
+        when(powerTrainMapper.findTorque(anyLong())).thenReturn(generatePowertrainTorqueEntity());
+        when(bodyTypeMapper.findBodytypesByCarId(carId)).thenReturn(generateCarBodyTypeEntities());
+        when(driveTrainMapper.findDrivetrainsByCarId(carId)).thenReturn(generateCarDrivetrainEntities());
+
+        //when
+        ModelTypeDto modelTypeDto = modelTypeService.findModelTypes(carId);
+        CarPowertrainDto carPowertrainDto = modelTypeDto.getPowertrains().get(0);
+        CarBodytypeDto carBodytypeDto = modelTypeDto.getBodytypes().get(0);
+        CarDrivetrainDto carDrivetrainDto = modelTypeDto.getDrivetrains().get(0);
+
+        //then
+        softly.assertThat(carPowertrainDto.getName()).as("파워트레인 이름은 powertrain1이다.").isEqualTo("powertrain1");
+        softly.assertThat(carPowertrainDto.getImage()).as("파워트레인 이미지는 img_url1이다.").isEqualTo("img_url1");
+        softly.assertThat(carBodytypeDto.getName()).as("바디타입 이름은 name1이다.").isEqualTo("name1");
+        softly.assertThat(carBodytypeDto.getDescription()).as("바디타입 세부 설명은 description1이다.").isEqualTo("description1");
+        softly.assertThat(carDrivetrainDto.getName()).as("구동방식 이름은 name 1이다.").isEqualTo("name1");
+        softly.assertThat(carDrivetrainDto.getDescription()).as("구동방식 세부 설명은 description1이다.").isEqualTo("description1");
+    }
+
+    @ParameterizedTest
+    @DisplayName("존재하지 않는 차량에 대해서 NoSuchCarException을 발생시킨다.")
+    @MethodSource("provideInvalidResultsOfMappers")
+    void findModelTypesNotExists(List<CarPowerTrainEntity> carPowerTrainEntities,
+                                 PowertrainOutputEntity powertrainOutputEntity,
+                                 PowertrainTorqueEntity powertrainTorqueEntity,
+                                 List<CarBodytypeEntity> carBodytypeEntities,
+                                 List<CarDrivetrainEntity> carDrivetrainEntities) {
+        //given
+        Long carId = 1L;
+        when(powerTrainMapper.findPowertrainsByCarId(carId)).thenReturn(carPowerTrainEntities);
+        when(powerTrainMapper.findOutput(anyLong())).thenReturn(powertrainOutputEntity);
+        when(powerTrainMapper.findTorque(anyLong())).thenReturn(powertrainTorqueEntity);
+        when(bodyTypeMapper.findBodytypesByCarId(carId)).thenReturn(carBodytypeEntities);
+        when(driveTrainMapper.findDrivetrainsByCarId(carId)).thenReturn(carDrivetrainEntities);
 
         //when
         //then
+        assertThatThrownBy(() -> modelTypeService.findModelTypes(carId))
+                .isInstanceOf(NoSuchCarException.class);
+    }
+
+    public static Stream<Arguments> provideInvalidResultsOfMappers() {
+        return Stream.of(
+                Arguments.of(
+                        List.of(),
+                        generatePowertrainOutputEntity(),
+                        generatePowertrainTorqueEntity(),
+                        generateCarBodyTypeEntities(),
+                        generateCarDrivetrainEntities()
+                ),
+                Arguments.of(
+                        generateCarPowerTrainEntities(),
+                        null,
+                        generatePowertrainTorqueEntity(),
+                        generateCarBodyTypeEntities(),
+                        generateCarDrivetrainEntities()
+                ),
+                Arguments.of(
+                        generateCarPowerTrainEntities(),
+                        generatePowertrainOutputEntity(),
+                        null,
+                        generateCarBodyTypeEntities(),
+                        generateCarDrivetrainEntities()
+                ),
+                Arguments.of(
+                        generateCarPowerTrainEntities(),
+                        generatePowertrainOutputEntity(),
+                        generatePowertrainTorqueEntity(),
+                        List.of(),
+                        generateCarDrivetrainEntities()
+                ),
+                Arguments.of(
+                        generateCarPowerTrainEntities(),
+                        generatePowertrainOutputEntity(),
+                        generatePowertrainTorqueEntity(),
+                        generateCarBodyTypeEntities(),
+                        List.of()
+                )
+        );
     }
 
     @Test

--- a/backend/src/test/java/com/h2o/h2oServer/domain/model_type/application/ModelTypeServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/model_type/application/ModelTypeServiceTest.java
@@ -1,0 +1,61 @@
+package com.h2o.h2oServer.domain.model_type.application;
+
+import com.h2o.h2oServer.domain.model_type.mapper.BodytypeMapper;
+import com.h2o.h2oServer.domain.model_type.mapper.DrivetrainMapper;
+import com.h2o.h2oServer.domain.model_type.mapper.PowertrainMapper;
+import com.h2o.h2oServer.domain.model_type.mapper.TechnicalSpecMapper;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+class ModelTypeServiceTest {
+    private ModelTypeService modelTypeService;
+    private PowertrainMapper powerTrainMapper;
+    private BodytypeMapper bodyTypeMapper;
+    private DrivetrainMapper driveTrainMapper;
+    private TechnicalSpecMapper technicalSpecMapper;
+    private SoftAssertions softly;
+
+    @BeforeEach
+    void setup() {
+        powerTrainMapper = Mockito.mock(PowertrainMapper.class);
+        bodyTypeMapper = Mockito.mock(BodytypeMapper.class);
+        driveTrainMapper = Mockito.mock(DrivetrainMapper.class);
+        technicalSpecMapper = Mockito.mock(TechnicalSpecMapper.class);
+        modelTypeService = new ModelTypeService(powerTrainMapper,
+                bodyTypeMapper,
+                driveTrainMapper,
+                technicalSpecMapper);
+        softly = new SoftAssertions();
+    }
+
+    @Test
+    @DisplayName("존재하는 차량에 대해서 ModelTypeDto를 반환한다.")
+    void findModelTypes() {
+        //given
+        Long carId = 1L;
+        when(powerTrainMapper.findPowertrainsByCarId(carId)).thenReturn();
+        when(powerTrainMapper.findOutput(anyLong())).thenReturn();
+        when(powerTrainMapper.findTorque(anyLong())).thenReturn();
+        when(bodyTypeMapper.findBodytypesByCarId(carId)).thenReturn();
+        when(driveTrainMapper.findDrivetrainsByCarId(carId)).thenReturn();
+
+        //when
+        //then
+    }
+
+    @Test
+    void findTechnicalSpec() {
+    }
+
+    @Test
+    void findDefaultModelType() {
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/model_type/mapper/BodytypeMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/model_type/mapper/BodytypeMapperTest.java
@@ -1,5 +1,6 @@
 package com.h2o.h2oServer.domain.model_type.mapper;
 
+import com.h2o.h2oServer.domain.model_type.CarBodyTypeFixture;
 import com.h2o.h2oServer.domain.model_type.Entity.BodytypeEntity;
 import com.h2o.h2oServer.domain.model_type.Entity.CarBodytypeEntity;
 import org.assertj.core.api.SoftAssertions;
@@ -31,12 +32,7 @@ class BodytypeMapperTest {
     void findById() {
         //given
         Long bodytypeId = 1L;
-        BodytypeEntity bodytype = BodytypeEntity.builder()
-                .id(bodytypeId)
-                .name("name1")
-                .description("description1")
-                .image("img_url1")
-                .build();
+        BodytypeEntity bodytype = CarBodyTypeFixture.generateBodytypeEntity();
 
         //when
         BodytypeEntity foundBodytype = bodytypeMapper.findById(bodytypeId);
@@ -52,25 +48,7 @@ class BodytypeMapperTest {
     void findBodytypeByCarId() {
         //given
         Long carId = 1L;
-        CarBodytypeEntity entity1 = CarBodytypeEntity.builder()
-                .carId(carId)
-                .name("name1")
-                .description("description1")
-                .image("img_url1")
-                .bodytypeId(1L)
-                .price(10000)
-                .choiceRatio(0.11f)
-                .build();
-
-        CarBodytypeEntity entity2 = CarBodytypeEntity.builder()
-                .carId(carId)
-                .name("name2")
-                .description("description2")
-                .image("img_url2")
-                .bodytypeId(2L)
-                .price(20000)
-                .choiceRatio(0.21f)
-                .build();
+        List<CarBodytypeEntity> expectedCarBodytypeEntities = CarBodyTypeFixture.generateCarBodyTypeEntities();
 
         //when
         List<CarBodytypeEntity> foundEntities = bodytypeMapper.findBodytypesByCarId(carId);
@@ -81,8 +59,7 @@ class BodytypeMapperTest {
         softly.assertThat(foundEntities).as("유효한 데이터만 매핑되었는지 확인")
                 .hasSize(2);
         softly.assertThat(foundEntities).as("carId에 해당하는 Entity가 모두 매핑되었는지 확인")
-                .contains(entity1)
-                .contains(entity2);
+                .containsAll(expectedCarBodytypeEntities);
         softly.assertAll();
     }
 

--- a/backend/src/test/java/com/h2o/h2oServer/domain/model_type/mapper/BodytypeMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/model_type/mapper/BodytypeMapperTest.java
@@ -1,6 +1,6 @@
 package com.h2o.h2oServer.domain.model_type.mapper;
 
-import com.h2o.h2oServer.domain.model_type.CarBodyTypeFixture;
+import com.h2o.h2oServer.domain.model_type.BodyTypeFixture;
 import com.h2o.h2oServer.domain.model_type.Entity.BodytypeEntity;
 import com.h2o.h2oServer.domain.model_type.Entity.CarBodytypeEntity;
 import org.assertj.core.api.SoftAssertions;
@@ -32,7 +32,7 @@ class BodytypeMapperTest {
     void findById() {
         //given
         Long bodytypeId = 1L;
-        BodytypeEntity bodytype = CarBodyTypeFixture.generateBodytypeEntity();
+        BodytypeEntity bodytype = BodyTypeFixture.generateBodytypeEntity();
 
         //when
         BodytypeEntity foundBodytype = bodytypeMapper.findById(bodytypeId);
@@ -48,7 +48,7 @@ class BodytypeMapperTest {
     void findBodytypeByCarId() {
         //given
         Long carId = 1L;
-        List<CarBodytypeEntity> expectedCarBodytypeEntities = CarBodyTypeFixture.generateCarBodyTypeEntities();
+        List<CarBodytypeEntity> expectedCarBodytypeEntities = BodyTypeFixture.generateCarBodyTypeEntities();
 
         //when
         List<CarBodytypeEntity> foundEntities = bodytypeMapper.findBodytypesByCarId(carId);

--- a/backend/src/test/java/com/h2o/h2oServer/domain/model_type/mapper/DrivetrainMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/model_type/mapper/DrivetrainMapperTest.java
@@ -1,5 +1,6 @@
 package com.h2o.h2oServer.domain.model_type.mapper;
 
+import com.h2o.h2oServer.domain.model_type.DrivetrainFixture;
 import com.h2o.h2oServer.domain.model_type.Entity.CarDrivetrainEntity;
 import com.h2o.h2oServer.domain.model_type.Entity.DrivetrainEntity;
 import org.assertj.core.api.SoftAssertions;
@@ -31,12 +32,7 @@ class DrivetrainMapperTest {
     void findById() {
         //given
         Long drivetrainId = 1L;
-        DrivetrainEntity drivetrain = DrivetrainEntity.builder()
-                .id(1L)
-                .name("name1")
-                .description("description1")
-                .image("img_url1")
-                .build();
+        DrivetrainEntity drivetrain = DrivetrainFixture.generateDrivetrainEntity(drivetrainId);
 
         //when
         DrivetrainEntity foundDrivetrain = drivetrainMapper.findById(drivetrainId);
@@ -52,37 +48,17 @@ class DrivetrainMapperTest {
     void findDrivetrainsByCarId() {
         //given
         Long carId = 1L;
-        CarDrivetrainEntity entity1 = CarDrivetrainEntity.builder()
-                .carId(carId)
-                .name("name1")
-                .description("description1")
-                .image("img_url1")
-                .drivetrainId(1L)
-                .price(10000)
-                .choiceRatio(0.22f)
-                .build();
 
-        CarDrivetrainEntity entity2 = CarDrivetrainEntity.builder()
-                .carId(carId)
-                .name("name2")
-                .description("description2")
-                .image("img_url2")
-                .drivetrainId(2L)
-                .price(20000)
-                .choiceRatio(0.23f)
-                .build();
+        List<CarDrivetrainEntity> carDrivetrainEntities = DrivetrainFixture.generateCarDrivetrainEntities(1L);
 
         //when
         List<CarDrivetrainEntity> foundEntities = drivetrainMapper.findDrivetrainsByCarId(carId);
 
         //then
-        softly.assertThat(foundEntities).as("유효한 데이터가 매핑되었는지 확인")
-                .isNotEmpty();
         softly.assertThat(foundEntities).as("유효한 데이터만 매핑되었는지 확인")
                 .hasSize(2);
         softly.assertThat(foundEntities).as("carId에 해당하는 Entity가 모두 매핑되었는지 확인")
-                .contains(entity1)
-                .contains(entity2);
+                .containsAll(carDrivetrainEntities);
 
         softly.assertAll();
     }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/model_type/mapper/PowertrainMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/model_type/mapper/PowertrainMapperTest.java
@@ -4,6 +4,7 @@ import com.h2o.h2oServer.domain.model_type.Entity.CarPowerTrainEntity;
 import com.h2o.h2oServer.domain.model_type.Entity.PowertrainEntity;
 import com.h2o.h2oServer.domain.model_type.Entity.PowertrainOutputEntity;
 import com.h2o.h2oServer.domain.model_type.Entity.PowertrainTorqueEntity;
+import com.h2o.h2oServer.domain.model_type.PowertrainFixture;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.*;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
@@ -33,12 +34,7 @@ class PowertrainMapperTest {
     void findById() {
         //given
         Long powertrainId = 1L;
-        PowertrainEntity powertrain = PowertrainEntity.builder()
-                .id(powertrainId)
-                .name("powertrain1")
-                .description("description1")
-                .image("img_url1")
-                .build();
+        PowertrainEntity powertrain = PowertrainFixture.generatePowertrainEntity(powertrainId);
 
         //when
         PowertrainEntity foundPowertrain = powertrainMapper.findById(powertrainId);
@@ -53,12 +49,7 @@ class PowertrainMapperTest {
     void findOutput() {
         //given
         Long powertrainId = 1L;
-        PowertrainOutputEntity output = PowertrainOutputEntity.builder()
-                .powertrainId(powertrainId)
-                .output(202.2f)
-                .minRpm(1000)
-                .maxRpm(1000)
-                .build();
+        PowertrainOutputEntity output = PowertrainFixture.generatePowertrainOutputEntity(powertrainId);
 
         //when
         PowertrainOutputEntity foundOutput = powertrainMapper.findOutput(powertrainId);
@@ -73,12 +64,7 @@ class PowertrainMapperTest {
     void findTorque() {
         //given
         Long powertrainId = 1L;
-        PowertrainTorqueEntity torque = PowertrainTorqueEntity.builder()
-                .powertrainId(powertrainId)
-                .torque(100.1f)
-                .minRpm(3000)
-                .maxRpm(3000)
-                .build();
+        PowertrainTorqueEntity torque = PowertrainFixture.generatePowertrainTorqueEntity(powertrainId);
 
         //when
         PowertrainTorqueEntity foundTorque = powertrainMapper.findTorque(powertrainId);
@@ -93,38 +79,17 @@ class PowertrainMapperTest {
     void findPowertrainsByCarId() {
         //given
         Long carId = 1L;
-        CarPowerTrainEntity entity1 = CarPowerTrainEntity.builder()
-                .carId(carId)
-                .name("powertrain1")
-                .description("description1")
-                .image("img_url1")
-                .powertrainId(1L)
-                .price(100000)
-                .choiceRatio(0.22f)
-                .build();
 
-        CarPowerTrainEntity entity2 = CarPowerTrainEntity.builder()
-                .carId(carId)
-                .name("powertrain2")
-                .description("description2")
-                .image("img_url2")
-                .powertrainId(2L)
-                .price(300000)
-                .choiceRatio(0.21f)
-                .build();
+        List<CarPowerTrainEntity> expectedCarPowerTrainEntities = PowertrainFixture.generateCarPowerTrainEntities(carId);
 
         //when
         List<CarPowerTrainEntity> foundEntities = powertrainMapper.findPowertrainsByCarId(carId);
 
         //then
-        softly.assertThat(foundEntities).as("유효한 데이터가 매핑되었는지 확인")
-                .isNotEmpty();
         softly.assertThat(foundEntities).as("유효한 데이터만 매핑되었는지 확인")
                 .hasSize(2);
         softly.assertThat(foundEntities).as("carId에 해당하는 Entity가 모두 매핑되었는지 확인")
-                .contains(entity1)
-                .contains(entity2);
-
+                .containsAll(expectedCarPowerTrainEntities);
         softly.assertAll();
     }
 

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/HashTagFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/HashTagFixture.java
@@ -1,0 +1,23 @@
+package com.h2o.h2oServer.domain.option;
+
+import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
+import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
+
+import java.util.List;
+
+public class HashTagFixture {
+
+    public static List<HashTagEntity> generateHashTagEntities() {
+        return List.of(
+                HashTagEntity.builder()
+                        .name(HashTag.CAMPING)
+                        .build(),
+                HashTagEntity.builder()
+                        .name(HashTag.LEISURE)
+                        .build(),
+                HashTagEntity.builder()
+                        .name(HashTag.SPORTS)
+                        .build()
+        );
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/OptionFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/OptionFixture.java
@@ -1,0 +1,22 @@
+package com.h2o.h2oServer.domain.option;
+
+import com.h2o.h2oServer.domain.trim.entity.OptionStatisticsEntity;
+
+import java.util.List;
+
+public class OptionFixture {
+    public static List<OptionStatisticsEntity> generateOptionStatisticsList() {
+        return List.of(
+                OptionStatisticsEntity.builder()
+                        .id(1L)
+                        .name("Option A")
+                        .useCount(0.75F)
+                        .build(),
+                OptionStatisticsEntity.builder()
+                        .id(2L)
+                        .name("Option B")
+                        .useCount(0.5F)
+                        .build()
+        );
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/OptionFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/OptionFixture.java
@@ -1,5 +1,7 @@
 package com.h2o.h2oServer.domain.option;
 
+import com.h2o.h2oServer.domain.option.entity.OptionDetailsEntity;
+import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
 import com.h2o.h2oServer.domain.trim.entity.OptionStatisticsEntity;
 
 import java.util.List;
@@ -18,5 +20,18 @@ public class OptionFixture {
                         .useCount(0.5F)
                         .build()
         );
+    }
+
+    public static OptionDetailsEntity generateOptionDetailsEntity() {
+        return OptionDetailsEntity.builder()
+                .name("Option 1")
+                .image("image_url_1")
+                .description("Description for Option 1")
+                .choiceRatio(0.3f)
+                .useCount(12.5f)
+                .category(OptionCategory.POWERTRAIN_PERFORMANCE)
+                .price(500)
+                .optionType("default")
+                .build();
     }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/OptionFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/OptionFixture.java
@@ -1,6 +1,7 @@
 package com.h2o.h2oServer.domain.option;
 
 import com.h2o.h2oServer.domain.option.entity.OptionDetailsEntity;
+import com.h2o.h2oServer.domain.option.entity.OptionEntity;
 import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
 import com.h2o.h2oServer.domain.trim.entity.OptionStatisticsEntity;
 
@@ -32,6 +33,16 @@ public class OptionFixture {
                 .category(OptionCategory.POWERTRAIN_PERFORMANCE)
                 .price(500)
                 .optionType("default")
+                .build();
+    }
+
+    public static OptionEntity generateOptionEntity() {
+        return OptionEntity.builder()
+                .name("Option 1")
+                .image("image_url_1")
+                .description("Description for Option 1")
+                .useCount(12.5f)
+                .category(OptionCategory.POWERTRAIN_PERFORMANCE)
                 .build();
     }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/application/OptionServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/application/OptionServiceTest.java
@@ -1,10 +1,8 @@
 package com.h2o.h2oServer.domain.option.application;
 
+import com.h2o.h2oServer.domain.option.OptionFixture;
 import com.h2o.h2oServer.domain.option.dto.OptionDetailsDto;
 import com.h2o.h2oServer.domain.option.dto.OptionStatisticsDto;
-import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
-import com.h2o.h2oServer.domain.option.entity.OptionDetailsEntity;
-import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
 import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
 import com.h2o.h2oServer.domain.option.mapper.OptionMapper;
 import org.assertj.core.api.SoftAssertions;
@@ -13,8 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.util.List;
-
+import static com.h2o.h2oServer.domain.option.HashTagFixture.generateHashTagEntities;
 import static org.mockito.Mockito.when;
 
 class OptionServiceTest {
@@ -35,7 +32,7 @@ class OptionServiceTest {
         //given
         long optionId = 1L;
         long trimId = 1L;
-        when(optionMapper.findOptionDetails(optionId, trimId)).thenReturn(generateOptionEntity());
+        when(optionMapper.findOptionDetails(optionId, trimId)).thenReturn(OptionFixture.generateOptionDetailsEntity());
         when(optionMapper.findHashTag(optionId)).thenReturn(generateHashTagEntities());
 
         //when
@@ -48,30 +45,5 @@ class OptionServiceTest {
         softly.assertThat(actualOptionDetailsDto.getCategory()).as("category = 성능/파워트레인").isEqualTo(OptionCategory.POWERTRAIN_PERFORMANCE.getLabel());
         softly.assertThat(actualOptionDetailsDto.getHmgData()).as("유효한 hmgData를 포함한다.").isEqualTo(OptionStatisticsDto.of(0.3f, 13));
         softly.assertAll();
-    }
-
-    private static List<HashTagEntity> generateHashTagEntities() {
-        return List.of(
-                HashTagEntity.builder()
-                        .name(HashTag.CAMPING)
-                        .build(),
-                HashTagEntity.builder()
-                        .name(HashTag.LEISURE)
-                        .build(),
-                HashTagEntity.builder()
-                        .name(HashTag.SPORTS)
-                        .build()
-        );
-    }
-
-    private static OptionDetailsEntity generateOptionEntity() {
-        return OptionDetailsEntity.builder()
-                .name("Option 1")
-                .image("image_url_1")
-                .description("Description for Option 1")
-                .choiceRatio(0.3f)
-                .useCount(12.5f)
-                .category(OptionCategory.POWERTRAIN_PERFORMANCE)
-                .build();
     }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/application/OptionServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/application/OptionServiceTest.java
@@ -2,16 +2,20 @@ package com.h2o.h2oServer.domain.option.application;
 
 import com.h2o.h2oServer.domain.option.OptionFixture;
 import com.h2o.h2oServer.domain.option.dto.OptionDetailsDto;
+import com.h2o.h2oServer.domain.option.dto.OptionDto;
 import com.h2o.h2oServer.domain.option.dto.OptionStatisticsDto;
 import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
+import com.h2o.h2oServer.domain.option.exception.NoSuchOptionException;
 import com.h2o.h2oServer.domain.option.mapper.OptionMapper;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static com.h2o.h2oServer.domain.option.HashTagFixture.generateHashTagEntities;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 class OptionServiceTest {
@@ -26,24 +30,76 @@ class OptionServiceTest {
         softly = new SoftAssertions();
     }
 
-    @Test
-    @DisplayName("존재하는 option, trim에 대한 요청인 경우 Dto로 formatting해서 반환한다.")
-    void findOptionInformation() {
-        //given
-        long optionId = 1L;
-        long trimId = 1L;
-        when(optionMapper.findOptionDetails(optionId, trimId)).thenReturn(OptionFixture.generateOptionDetailsEntity());
-        when(optionMapper.findHashTag(optionId)).thenReturn(generateHashTagEntities());
+    @Nested
+    @DisplayName("옵션 세부 정보 테스트")
+    class findDetailedOptionInformationTest {
+        @Test
+        @DisplayName("존재하는 option, trim에 대한 요청인 경우 Dto로 formatting해서 반환한다.")
+        void findDetailedOptionInformation() {
+            //given
+            long optionId = 1L;
+            long trimId = 1L;
+            when(optionMapper.findOptionDetails(optionId, trimId)).thenReturn(OptionFixture.generateOptionDetailsEntity());
+            when(optionMapper.findHashTag(optionId)).thenReturn(generateHashTagEntities());
 
-        //when
-        OptionDetailsDto actualOptionDetailsDto = optionService.findOptionInformation(optionId, trimId);
+            //when
+            OptionDetailsDto actualOptionDetailsDto = optionService.findDetailedOptionInformation(optionId, trimId);
 
-        //then
-        softly.assertThat(actualOptionDetailsDto).as("null이 아니다.").isNotNull();
-        softly.assertThat(actualOptionDetailsDto.getHashTags()).as("세 개의 hashtag 정보를 포함한다.").hasSize(3);
-        softly.assertThat(actualOptionDetailsDto.getName()).as("name = Option 1이다.").isEqualTo("Option 1");
-        softly.assertThat(actualOptionDetailsDto.getCategory()).as("category = 성능/파워트레인").isEqualTo(OptionCategory.POWERTRAIN_PERFORMANCE.getLabel());
-        softly.assertThat(actualOptionDetailsDto.getHmgData()).as("유효한 hmgData를 포함한다.").isEqualTo(OptionStatisticsDto.of(0.3f, 13));
-        softly.assertAll();
+            //then
+            softly.assertThat(actualOptionDetailsDto).as("null이 아니다.").isNotNull();
+            softly.assertThat(actualOptionDetailsDto.getHashTags()).as("세 개의 hashtag 정보를 포함한다.").hasSize(3);
+            softly.assertThat(actualOptionDetailsDto.getName()).as("name = Option 1이다.").isEqualTo("Option 1");
+            softly.assertThat(actualOptionDetailsDto.getCategory()).as("category = 성능/파워트레인").isEqualTo(OptionCategory.POWERTRAIN_PERFORMANCE.getLabel());
+            softly.assertThat(actualOptionDetailsDto.getHmgData()).as("유효한 hmgData를 포함한다.").isEqualTo(OptionStatisticsDto.of(0.3f, 13));
+            softly.assertAll();
+        }
+        @Test
+        @DisplayName("존재하지 않는 option에 대한 요청인 경우 NoSuchOptionException을 발생시킨다.")
+        void findDetailedOptionInformationNotExists() {
+            //given
+            long optionId = 1L;
+            long trimId = 1L;
+            when(optionMapper.findOptionDetails(optionId, trimId)).thenReturn(null);
+
+            //when
+            //then
+            assertThatThrownBy(() -> optionService.findDetailedOptionInformation(optionId, trimId))
+                    .isInstanceOf(NoSuchOptionException.class);
+        }
+    }
+    @Nested
+    @DisplayName("옵션 정보 반환 테스트")
+    class findOptionInformationTest {
+        @Test
+        @DisplayName("존재하는 option에 대한 요청인 경우 Dto로 formatting해서 반환한다.")
+        void findOptionInformation() {
+            //given
+            long optionId = 1L;
+            when(optionMapper.findOption(optionId)).thenReturn(OptionFixture.generateOptionEntity());
+            when(optionMapper.findHashTag(optionId)).thenReturn(generateHashTagEntities());
+
+            //when
+            OptionDto actualOptionDto = optionService.findOptionInformation(optionId);
+
+            //then
+            softly.assertThat(actualOptionDto).as("null이 아니다.").isNotNull();
+            softly.assertThat(actualOptionDto.getHashTags()).as("세 개의 hashtag 정보를 포함한다.").hasSize(3);
+            softly.assertThat(actualOptionDto.getName()).as("name = Option 1이다.").isEqualTo("Option 1");
+            softly.assertThat(actualOptionDto.getCategory()).as("category = 성능/파워트레인").isEqualTo(OptionCategory.POWERTRAIN_PERFORMANCE.getLabel());
+            softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 option에 대한 요청인 경우 NoSuchOptionException을 발생시킨다.")
+        void findOptionInformationNotExists() {
+            //given
+            long optionId = 1L;
+            when(optionMapper.findOption(optionId)).thenReturn(null);
+
+            //when
+            //then
+            assertThatThrownBy(() -> optionService.findOptionInformation(optionId))
+                    .isInstanceOf(NoSuchOptionException.class);
+        }
     }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/mapper/OptionMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/mapper/OptionMapperTest.java
@@ -6,6 +6,7 @@ import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
 import com.h2o.h2oServer.domain.option.entity.OptionDetailsEntity;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +21,7 @@ class OptionMapperTest {
 
     @Autowired
     private OptionMapper optionMapper;
-    private SoftAssertions softly = new SoftAssertions();
+    private final SoftAssertions softly = new SoftAssertions();
 
     @Test
     @DisplayName("존재하는 trim, option에 대해서 유효한 OptionEntity 객체를 반환한다.")
@@ -52,39 +53,38 @@ class OptionMapperTest {
         List<HashTagEntity> actualHashTagEntities = optionMapper.findHashTag(optionId);
 
         //then
-        softly.assertThat(actualHashTagEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
-        softly.assertThat(actualHashTagEntities).as("optionId에 해당하는 HashTagEntity 객체가 모두 매핑되었는지 확인")
-                .contains(expectedHashTagEntities.get(0))
-                .contains(expectedHashTagEntities.get(1))
-                .contains(expectedHashTagEntities.get(2));
-        softly.assertAll();
+        assertThat(actualHashTagEntities).as("optionId에 해당하는 HashTagEntity 객체가 모두 매핑되었는지 확인")
+                .containsAll(expectedHashTagEntities);
     }
 
-    @Test
-    @DisplayName("존재하는 옵션인 경우 true를 반환한다.")
+    @Nested
+    @DisplayName("존재 여부 확인 쿼리 테스트")
     @Sql("classpath:db/option/option-data.sql")
-    void checkIfOptionExists() {
-        //given
-        Long optionId = 1L;
+    class CheckIfOptionExists {
+        @Test
+        @DisplayName("존재하는 옵션인 경우 true를 반환한다.")
+        void checkIfOptionExists() {
+            //given
+            Long optionId = 1L;
 
-        //when
-        Boolean isExists = optionMapper.checkIfOptionExists(optionId);
+            //when
+            Boolean isExists = optionMapper.checkIfOptionExists(optionId);
 
-        //then
-        assertThat(isExists).isTrue();
-    }
+            //then
+            assertThat(isExists).isTrue();
+        }
 
-    @Test
-    @DisplayName("존재하지 않는 옵션인 경우 false를 반환한다.")
-    @Sql("classpath:db/option/option-data.sql")
-    void checkIfOptionExistsFalse() {
-        //given
-        Long optionId = 5L;
+        @Test
+        @DisplayName("존재하지 않는 옵션인 경우 false를 반환한다.")
+        void checkIfOptionExistsFalse() {
+            //given
+            Long optionId = 5L;
 
-        //when
-        Boolean isExists = optionMapper.checkIfOptionExists(optionId);
+            //when
+            Boolean isExists = optionMapper.checkIfOptionExists(optionId);
 
-        //then
-        assertThat(isExists).isFalse();
+            //then
+            assertThat(isExists).isFalse();
+        }
     }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/mapper/OptionMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/mapper/OptionMapperTest.java
@@ -1,9 +1,9 @@
 package com.h2o.h2oServer.domain.option.mapper;
 
+import com.h2o.h2oServer.domain.option.HashTagFixture;
+import com.h2o.h2oServer.domain.option.OptionFixture;
 import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
 import com.h2o.h2oServer.domain.option.entity.OptionDetailsEntity;
-import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
-import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,16 +29,7 @@ class OptionMapperTest {
         //given
         Long trimId = 1L;
         Long optionId = 1L;
-        OptionDetailsEntity expectedOptionDetailsEntity = OptionDetailsEntity.builder()
-                .name("Option 1")
-                .image("image_url_1")
-                .description("Description for Option 1")
-                .choiceRatio(0.3f)
-                .useCount(12.5f)
-                .category(OptionCategory.POWERTRAIN_PERFORMANCE)
-                .price(500)
-                .optionType("default")
-                .build();
+        OptionDetailsEntity expectedOptionDetailsEntity = OptionFixture.generateOptionDetailsEntity();
 
         //when
         OptionDetailsEntity actualOptionDetailsEntity = optionMapper.findOptionDetails(optionId, trimId);
@@ -55,17 +46,7 @@ class OptionMapperTest {
     void findHashTag() {
         //given
         Long optionId = 1L;
-        List<HashTagEntity> expectedHashTagEntities = List.of(
-                HashTagEntity.builder()
-                        .name(HashTag.CAMPING)
-                        .build(),
-                HashTagEntity.builder()
-                        .name(HashTag.LEISURE)
-                        .build(),
-                HashTagEntity.builder()
-                        .name(HashTag.SPORTS)
-                        .build()
-        );
+        List<HashTagEntity> expectedHashTagEntities = HashTagFixture.generateHashTagEntities();
 
         //when
         List<HashTagEntity> actualHashTagEntities = optionMapper.findHashTag(optionId);

--- a/backend/src/test/java/com/h2o/h2oServer/domain/optionPackage/PackageFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/optionPackage/PackageFixture.java
@@ -1,0 +1,15 @@
+package com.h2o.h2oServer.domain.optionPackage;
+
+import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
+import com.h2o.h2oServer.domain.optionPackage.entity.PackageEntity;
+
+public class PackageFixture {
+    public static PackageEntity generatePackageEntity() {
+        return PackageEntity.builder()
+                .name("Package 1")
+                .category(OptionCategory.DETAILED_ITEM)
+                .choiceRatio(0.7f)
+                .price(500)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/optionPackage/application/PackageServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/optionPackage/application/PackageServiceTest.java
@@ -2,11 +2,9 @@ package com.h2o.h2oServer.domain.optionPackage.application;
 
 import com.h2o.h2oServer.domain.option.application.OptionService;
 import com.h2o.h2oServer.domain.option.dto.OptionDto;
-import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
-import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
 import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
+import com.h2o.h2oServer.domain.optionPackage.PackageFixture;
 import com.h2o.h2oServer.domain.optionPackage.dto.PackageDetailsDto;
-import com.h2o.h2oServer.domain.optionPackage.entity.PackageEntity;
 import com.h2o.h2oServer.domain.optionPackage.mapper.PackageMapper;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -17,6 +15,7 @@ import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 
 import java.util.List;
 
+import static com.h2o.h2oServer.domain.option.HashTagFixture.generateHashTagEntities;
 import static org.mockito.Mockito.when;
 
 @MybatisTest
@@ -40,56 +39,44 @@ class PackageServiceTest {
         //given
         Long trimId = 1L;
         Long packageId = 1L;
-        when(packageMapper.findPackage(trimId, packageId)).thenReturn(generatePackageEntity());
+        List<OptionDto> expectedOptionDtos = generateOptionDtos();
+        when(packageMapper.findPackage(trimId, packageId)).thenReturn(PackageFixture.generatePackageEntity());
         when(packageMapper.findHashTag(packageId)).thenReturn(generateHashTagEntities());
         when(packageMapper.findOptionComponent(packageId)).thenReturn(List.of(1L, 2L));
-        when(optionService.findOptionInformation(1L)).thenReturn(OptionDto.builder()
-                .name("first")
-                .containsHmgData(true)
-                .build());
-        when(optionService.findOptionInformation(2L)).thenReturn(OptionDto.builder()
-                .name("second")
-                .containsHmgData(false)
-                .build());
+        when(optionService.findOptionInformation(1L)).thenReturn(expectedOptionDtos.get(0));
+        when(optionService.findOptionInformation(2L)).thenReturn(expectedOptionDtos.get(1));
 
         //when
         PackageDetailsDto actualPackageDetailsDto = packageService.findPackageInformation(trimId, packageId);
         //then
-        softly.assertThat(actualPackageDetailsDto).as("null이 아니다.").isNotNull();
-        softly.assertThat(actualPackageDetailsDto.getHashTags()).as("세 개의 hashtag 정보를 포함한다.").hasSize(3);
-        softly.assertThat(actualPackageDetailsDto.getName()).as("name = package name이다.").isEqualTo("package name");
-        softly.assertThat(actualPackageDetailsDto.getCategory()).as("category = 편의").isEqualTo(OptionCategory.CONVENIENCE.getLabel());
-        softly.assertThat(actualPackageDetailsDto.getComponents()).as("유효한 hmgData를 포함한다.").contains(OptionDto.builder()
-                .name("second")
-                .containsHmgData(false)
-                .build())
-                .contains(OptionDto.builder()
-                .name("first")
-                .containsHmgData(true)
-                .build());
+        softly.assertThat(actualPackageDetailsDto)
+                .as("null이 아니다.")
+                .isNotNull();
+        softly.assertThat(actualPackageDetailsDto.getHashTags())
+                .as("세 개의 hashtag 정보를 포함한다.")
+                .hasSize(3);
+        softly.assertThat(actualPackageDetailsDto.getName())
+                .as("name = Package 1이다.")
+                .isEqualTo("Package 1");
+        softly.assertThat(actualPackageDetailsDto.getCategory())
+                .as("category = 세부상품")
+                .isEqualTo(OptionCategory.DETAILED_ITEM.getLabel());
+        softly.assertThat(actualPackageDetailsDto.getComponents())
+                .as("유효한 hmgData를 포함한다.")
+                .containsAll(expectedOptionDtos);
         softly.assertAll();
     }
 
-    private static PackageEntity generatePackageEntity() {
-        return PackageEntity.builder()
-                .name("package name")
-                .price(123)
-                .choiceRatio(0.3f)
-                .category(OptionCategory.CONVENIENCE)
-                .build();
+    private static List<OptionDto> generateOptionDtos() {
+        return List.of(
+                OptionDto.builder()
+                        .name("first")
+                        .containsHmgData(true)
+                        .build(),
+                OptionDto.builder()
+                        .name("second")
+                        .containsHmgData(false)
+                        .build());
     }
 
-    private static List<HashTagEntity> generateHashTagEntities() {
-        return List.of(
-                HashTagEntity.builder()
-                        .name(HashTag.CAMPING)
-                        .build(),
-                HashTagEntity.builder()
-                        .name(HashTag.LEISURE)
-                        .build(),
-                HashTagEntity.builder()
-                        .name(HashTag.SPORTS)
-                        .build()
-        );
-    }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/optionPackage/mapper/PackageMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/optionPackage/mapper/PackageMapperTest.java
@@ -1,11 +1,12 @@
 package com.h2o.h2oServer.domain.optionPackage.mapper;
 
+import com.h2o.h2oServer.domain.option.HashTagFixture;
 import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
-import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
-import com.h2o.h2oServer.domain.option.entity.enums.OptionCategory;
+import com.h2o.h2oServer.domain.optionPackage.PackageFixture;
 import com.h2o.h2oServer.domain.optionPackage.entity.PackageEntity;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,83 +23,110 @@ class PackageMapperTest {
     PackageMapper packageMapper;
     SoftAssertions softly = new SoftAssertions();
 
-    @Test
-    @DisplayName("존재하는 trim, package에 대해서 유효한 PackageEntity 객체를 반환한다.")
+    @Nested
+    @DisplayName("패키지 조회 테스트")
     @Sql("classpath:db/optionPackage/package-data.sql")
-    void findPackage() {
-        //given
-        Long packageId = 1L;
-        Long trimId = 2L;
-        PackageEntity expectedPackageEntity = PackageEntity.builder()
-                .name("Package 1")
-                .category(OptionCategory.DETAILED_ITEM)
-                .choiceRatio(0.7f)
-                .price(500)
-                .build();
+    class findPackageTest {
+        @Test
+        @DisplayName("존재하는 trim, package에 대해서 유효한 PackageEntity 객체를 반환한다.")
+        void findPackage() {
+            //given
+            Long packageId = 1L;
+            Long trimId = 2L;
+            PackageEntity expectedPackageEntity = PackageFixture.generatePackageEntity();
 
-        //when
-        PackageEntity actualPackageEntity = packageMapper.findPackage(trimId, packageId);
+            //when
+            PackageEntity actualPackageEntity = packageMapper.findPackage(trimId, packageId);
 
-        //then
-        softly.assertThat(actualPackageEntity).as("유효한 데이터가 매핑되었는지 확인").isNotNull();
-        softly.assertThat(actualPackageEntity).as("데이터베이스에 존재하는 데이터인지 확인").isEqualTo(expectedPackageEntity);
-        softly.assertAll();
+            //then
+            softly.assertThat(actualPackageEntity).as("유효한 데이터가 매핑되었는지 확인").isNotNull();
+            softly.assertThat(actualPackageEntity).as("데이터베이스에 존재하는 데이터인지 확인").isEqualTo(expectedPackageEntity);
+            softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 package에 대해서 null을 반환한다.")
+        void findPackageNotExists() {
+            //given
+            Long packageId = 4L;
+            Long trimId = 2L;
+
+            //when
+            PackageEntity actualPackageEntity = packageMapper.findPackage(trimId, packageId);
+
+            //then
+            assertThat(actualPackageEntity).isNull();
+        }
     }
 
-    @Test
-    @DisplayName("존재하는 package에 대해서 유효한 HashTagEntity 객체를 반환한다.")
+
+    @Nested
+    @DisplayName("패키지 해시태그 조회 테스트")
     @Sql("classpath:db/optionPackage/package-hashtag-data.sql")
-    void findHashTag() {
-        //given
-        Long packageId = 1L;
-        List<HashTagEntity> expectedHashTagEntities = List.of(
-                HashTagEntity.builder()
-                        .name(HashTag.CAMPING)
-                        .build(),
-                HashTagEntity.builder()
-                        .name(HashTag.LEISURE)
-                        .build(),
-                HashTagEntity.builder()
-                        .name(HashTag.SPORTS)
-                        .build()
-        );
-        //when
-        List<HashTagEntity> actualHashTagEntities = packageMapper.findHashTag(packageId);
+    class findHashTagTest {
+        @Test
+        @DisplayName("존재하는 package에 대해서 유효한 HashTagEntity 객체를 반환한다.")
+        void findHashTag() {
+            //given
+            Long packageId = 1L;
+            List<HashTagEntity> expectedHashTagEntities = HashTagFixture.generateHashTagEntities();
 
-        //then
-        softly.assertThat(actualHashTagEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
-        softly.assertThat(actualHashTagEntities).as("packageId에 해당하는 HashTagEntity 객체가 모두 매핑되었는지 확인")
-                .contains(expectedHashTagEntities.get(0))
-                .contains(expectedHashTagEntities.get(1))
-                .contains(expectedHashTagEntities.get(2));
-        softly.assertAll();
+            //when
+            List<HashTagEntity> actualHashTagEntities = packageMapper.findHashTag(packageId);
+
+            //then
+            softly.assertThat(actualHashTagEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
+            softly.assertThat(actualHashTagEntities).as("packageId에 해당하는 HashTagEntity 객체가 모두 매핑되었는지 확인")
+                    .contains(expectedHashTagEntities.get(0))
+                    .contains(expectedHashTagEntities.get(1))
+                    .contains(expectedHashTagEntities.get(2));
+            softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 package에 대해서 null을 반환한다.")
+        void findHashTagPackageNotExists() {
+            //given
+            Long packageId = 5L;
+
+            //when
+            List<HashTagEntity> actualHashTagEntities = packageMapper.findHashTag(packageId);
+
+            //then
+            assertThat(actualHashTagEntities).isEmpty();
+        }
     }
 
-    @Test
-    @DisplayName("존재하는 패키지인 경우 true를 반환한다.")
+    @Nested
+    @DisplayName("존재 여부 확인 쿼리 테스트")
     @Sql("classpath:db/optionPackage/package-data.sql")
-    void checkIfPackageExists() {
-        //given
-        Long id = 1L;
+    class CheckIfPackageExists {
+        @Test
+        @DisplayName("존재하는 패키지인 경우 true를 반환한다.")
+        void checkIfPackageExists() {
+            //given
+            Long id = 1L;
 
-        //when
-        Boolean isExists = packageMapper.checkIfPackageExists(id);
+            //when
+            Boolean isExists = packageMapper.checkIfPackageExists(id);
 
-        //then
-        assertThat(isExists).isTrue();
+            //then
+            assertThat(isExists).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 패키지인 경우 false를 반환한다.")
+        @Sql("classpath:db/optionPackage/package-data.sql")
+        void checkIfPackageExistsFalse() {
+            //given
+            Long id = 5L;
+
+            //when
+            Boolean isExists = packageMapper.checkIfPackageExists(id);
+
+            //then
+            assertThat(isExists).isFalse();
+        }
     }
 
-    @Test
-    @DisplayName("존재하지 않는 패키지인 경우 false를 반환한다.")
-    @Sql("classpath:db/optionPackage/package-data.sql")
-    void checkIfPackageExistsFalse() {
-        //given
-        Long id = 5L;
-
-        //when
-        Boolean isExists = packageMapper.checkIfPackageExists(id);
-
-        //then
-        assertThat(isExists).isFalse();
-    }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/quotation/QuotationFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/quotation/QuotationFixture.java
@@ -1,0 +1,24 @@
+package com.h2o.h2oServer.domain.quotation;
+
+import com.h2o.h2oServer.domain.model_type.dto.ModelTypeIdDto;
+import com.h2o.h2oServer.domain.quotation.dto.QuotationRequestDto;
+
+import java.util.List;
+
+public class QuotationFixture {
+    public static QuotationRequestDto generateQuotationRequestDto() {
+        return QuotationRequestDto.builder()
+                .carId(4L)
+                .trimId(5L)
+                .modelTypeIds(ModelTypeIdDto.builder()
+                        .bodytypeId(2L)
+                        .drivetrainId(3L)
+                        .powertrainId(1L)
+                        .build())
+                .externalColorId(7L)
+                .internalColorId(6L)
+                .optionIds(List.of(8L, 9L, 10L))
+                .packageIds(List.of(11L))
+                .build();
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/quotation/application/QuotationServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/quotation/application/QuotationServiceTest.java
@@ -14,6 +14,7 @@ import com.h2o.h2oServer.domain.option.mapper.OptionMapper;
 import com.h2o.h2oServer.domain.optionPackage.exception.NoSuchPackageException;
 import com.h2o.h2oServer.domain.optionPackage.mapper.PackageMapper;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationRequestDto;
+import com.h2o.h2oServer.domain.quotation.dto.QuotationResponseDto;
 import com.h2o.h2oServer.domain.quotation.mapper.QuotationMapper;
 import com.h2o.h2oServer.domain.trim.Exception.NoSuchTrimException;
 import com.h2o.h2oServer.domain.trim.mapper.ExternalColorMapper;
@@ -22,6 +23,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.test.context.jdbc.Sql;
 
 import static com.h2o.h2oServer.domain.quotation.QuotationFixture.generateQuotationRequestDto;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/backend/src/test/java/com/h2o/h2oServer/domain/quotation/application/QuotationServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/quotation/application/QuotationServiceTest.java
@@ -24,8 +24,7 @@ import org.mockito.Mockito;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.test.context.jdbc.Sql;
 
-import java.util.List;
-
+import static com.h2o.h2oServer.domain.quotation.QuotationFixture.generateQuotationRequestDto;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
@@ -89,7 +88,7 @@ class QuotationServiceTest {
 
             //when
             //then
-            assertThatThrownBy(() -> quotationService.saveQuotation(createMockRequest()))
+            assertThatThrownBy(() -> quotationService.saveQuotation(generateQuotationRequestDto()))
                     .isInstanceOf(NoSuchCarException.class);
         }
 
@@ -101,7 +100,7 @@ class QuotationServiceTest {
 
             //when
             //then
-            assertThatThrownBy(() -> quotationService.saveQuotation(createMockRequest()))
+            assertThatThrownBy(() -> quotationService.saveQuotation(generateQuotationRequestDto()))
                     .isInstanceOf(NoSuchTrimException.class);
         }
 
@@ -113,7 +112,7 @@ class QuotationServiceTest {
 
             //when
             //then
-            assertThatThrownBy(() -> quotationService.saveQuotation(createMockRequest()))
+            assertThatThrownBy(() -> quotationService.saveQuotation(generateQuotationRequestDto()))
                     .isInstanceOf(NoSuchPowertrainException.class);
         }
 
@@ -125,7 +124,7 @@ class QuotationServiceTest {
 
             //when
             //then
-            assertThatThrownBy(() -> quotationService.saveQuotation(createMockRequest()))
+            assertThatThrownBy(() -> quotationService.saveQuotation(generateQuotationRequestDto()))
                     .isInstanceOf(NoSuchBodyTypeException.class);
         }
 
@@ -137,7 +136,7 @@ class QuotationServiceTest {
 
             //when
             //then
-            assertThatThrownBy(() -> quotationService.saveQuotation(createMockRequest()))
+            assertThatThrownBy(() -> quotationService.saveQuotation(generateQuotationRequestDto()))
                     .isInstanceOf(NoSuchDriveTrainException.class);
         }
 
@@ -149,7 +148,7 @@ class QuotationServiceTest {
 
             //when
             //then
-            assertThatThrownBy(() -> quotationService.saveQuotation(createMockRequest()))
+            assertThatThrownBy(() -> quotationService.saveQuotation(generateQuotationRequestDto()))
                     .isInstanceOf(NoSuchOptionException.class);
         }
 
@@ -161,46 +160,29 @@ class QuotationServiceTest {
 
             //when
             //then
-            assertThatThrownBy(() -> quotationService.saveQuotation(createMockRequest()))
+            assertThatThrownBy(() -> quotationService.saveQuotation(generateQuotationRequestDto()))
                     .isInstanceOf(NoSuchPackageException.class);
         }
     }
 
-//    @Test
-//    @Sql("classpath:db/quotation/quotation-tx-data.sql")
-//    @DisplayName("견적이 저장되지 못하면 롤백된다.")
-//    void transaction() {
-//        //given
-//        QuotationRequestDto request = createMockRequest();
-//
-//        //when
-//        QuotationResponseDto quotationResponseDto = quotationService.saveQuotation(request);
-//
-//        //then
-//        softly.assertThat(quotationMapper.countQuotation())
-//                .as("id 충돌로 인해 Quotation 테이블에 대한 롤백이 일어난다.")
-//                .isEqualTo(0L);
-//        softly.assertThat(quotationResponseDto)
-//                .as("롤백되면 응답 객체가 생성되지 않는다.")
-//                .isNull();
-//        softly.assertAll();
-//    }
+    @Disabled
+    @Test
+    @Sql("classpath:db/quotation/quotation-tx-data.sql")
+    @DisplayName("견적이 저장되지 못하면 롤백된다.")
+    void transaction() {
+        //given
+        QuotationRequestDto request = generateQuotationRequestDto();
 
-    private QuotationRequestDto createMockRequest() {
-        ModelTypeIdDto modelTypeId = new ModelTypeIdDto();
-        modelTypeId.setPowertrainId(1L);
-        modelTypeId.setBodytypeId(2L);
-        modelTypeId.setDrivetrainId(3L);
+        //when
+        QuotationResponseDto quotationResponseDto = quotationService.saveQuotation(request);
 
-        QuotationRequestDto request = new QuotationRequestDto();
-        request.setCarId(4L);
-        request.setTrimId(5L);
-        request.setModelTypeIds(modelTypeId);
-        request.setInternalColorId(6L);
-        request.setExternalColorId(7L);
-        request.setOptionIds(List.of(8L, 9L, 10L));
-        request.setPackageIds(List.of(11L));
-
-        return request;
+        //then
+        softly.assertThat(quotationMapper.countQuotation())
+                .as("id 충돌로 인해 Quotation 테이블에 대한 롤백이 일어난다.")
+                .isEqualTo(0L);
+        softly.assertThat(quotationResponseDto)
+                .as("롤백되면 응답 객체가 생성되지 않는다.")
+                .isNull();
+        softly.assertAll();
     }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/quotation/mapper/QuotationMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/quotation/mapper/QuotationMapperTest.java
@@ -1,6 +1,5 @@
 package com.h2o.h2oServer.domain.quotation.mapper;
 
-import com.h2o.h2oServer.domain.model_type.dto.ModelTypeIdDto;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationDto;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationRequestDto;
 import com.h2o.h2oServer.domain.quotation.entity.OptionQuotationEntity;
@@ -8,11 +7,14 @@ import com.h2o.h2oServer.domain.quotation.entity.PackageQuotationEntity;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
+
+import static com.h2o.h2oServer.domain.quotation.QuotationFixture.generateQuotationRequestDto;
 
 @MybatisTest
 class QuotationMapperTest {
@@ -26,75 +28,61 @@ class QuotationMapperTest {
         softly = new SoftAssertions();
     }
 
-    @Test
-    @DisplayName("견적을 저장하면 견적 id가 생성된다.")
-    void saveQuotationReturnPK() {
-        //given
-        QuotationRequestDto request = createMockRequest();
-        QuotationDto quotationDto1 = QuotationDto.of(request);
-        QuotationDto quotationDto2 = QuotationDto.of(request);
+    @Nested
+    @DisplayName("견적 저장 테스트")
+    class saveQuotationsTest {
+        @Test
+        @DisplayName("견적을 저장하면 견적 id가 생성된다.")
+        void saveQuotationReturnPK() {
+            //given
+            QuotationRequestDto request = generateQuotationRequestDto();
+            QuotationDto quotationDto1 = QuotationDto.of(request);
+            QuotationDto quotationDto2 = QuotationDto.of(request);
 
-        //when
-        quotationMapper.saveQuotation(quotationDto1);
-        quotationMapper.saveQuotation(quotationDto2);
+            //when
+            quotationMapper.saveQuotation(quotationDto1);
+            quotationMapper.saveQuotation(quotationDto2);
 
-        //then
-        softly.assertThat(quotationDto1.getId()).as("id가 생성된다.")
-                .isNotNull();
-        softly.assertThat(quotationDto2.getId()).as("AUTO INCREMENT로 id가 정해진다.")
-                .isEqualTo(2L);
-        softly.assertAll();
-    }
+            //then
+            softly.assertThat(quotationDto1.getId()).as("id가 생성된다.")
+                    .isNotNull();
+            softly.assertThat(quotationDto2.getId()).as("AUTO INCREMENT로 id가 정해진다.")
+                    .isEqualTo(2L);
+            softly.assertAll();
+        }
 
-    @Test
-    @DisplayName("옵션 ID 리스트를 테이블에 저장하면 리스트의 개수만큼 레코드가 생성된다.")
-    void saveOptionQuotation() {
-        //given
-        OptionQuotationEntity optionQuotationEntity = OptionQuotationEntity.builder()
-                .quotationId(1L)
-                .optionIds(List.of(2L, 3L, 4L))
-                .build();
+        @Test
+        @DisplayName("옵션 ID 리스트를 테이블에 저장하면 리스트의 개수만큼 레코드가 생성된다.")
+        void saveOptionQuotation() {
+            //given
+            OptionQuotationEntity optionQuotationEntity = OptionQuotationEntity.builder()
+                    .quotationId(1L)
+                    .optionIds(List.of(2L, 3L, 4L))
+                    .build();
 
-        //when
-        quotationMapper.saveOptionQuotation(optionQuotationEntity);
+            //when
+            quotationMapper.saveOptionQuotation(optionQuotationEntity);
 
-        //then
-        softly.assertThat(quotationMapper.countOptionQuotation())
-                .isEqualTo(3L);
-    }
+            //then
+            softly.assertThat(quotationMapper.countOptionQuotation())
+                    .isEqualTo(3L);
+        }
 
-    @Test
-    @DisplayName("패키지 ID 리스트를 테이블에 저장하면 리스트의 개수만큼 레코드가 생성된다.")
-    void savePackageQuotation() {
-        //given
-        PackageQuotationEntity packageQuotationEntity = PackageQuotationEntity.builder()
-                .quotationId(1L)
-                .packageIds(List.of(5L, 6L))
-                .build();
+        @Test
+        @DisplayName("패키지 ID 리스트를 테이블에 저장하면 리스트의 개수만큼 레코드가 생성된다.")
+        void savePackageQuotation() {
+            //given
+            PackageQuotationEntity packageQuotationEntity = PackageQuotationEntity.builder()
+                    .quotationId(1L)
+                    .packageIds(List.of(5L, 6L))
+                    .build();
 
-        //when
-        quotationMapper.savePackageQuotation(packageQuotationEntity);
+            //when
+            quotationMapper.savePackageQuotation(packageQuotationEntity);
 
-        //then
-        softly.assertThat(quotationMapper.countPackageQuotation())
-                .isEqualTo(2L);
-    }
-
-    private QuotationRequestDto createMockRequest() {
-        ModelTypeIdDto modelTypeId = new ModelTypeIdDto();
-        modelTypeId.setPowertrainId(1L);
-        modelTypeId.setBodytypeId(2L);
-        modelTypeId.setDrivetrainId(3L);
-
-        QuotationRequestDto request = new QuotationRequestDto();
-        request.setCarId(4L);
-        request.setTrimId(5L);
-        request.setModelTypeIds(modelTypeId);
-        request.setInternalColorId(6L);
-        request.setExternalColorId(7L);
-        request.setOptionIds(List.of(8L, 9L, 10L));
-        request.setPackageIds(List.of(11L));
-
-        return request;
+            //then
+            softly.assertThat(quotationMapper.countPackageQuotation())
+                    .isEqualTo(2L);
+        }
     }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/ExternalColorFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/ExternalColorFixture.java
@@ -1,0 +1,25 @@
+package com.h2o.h2oServer.domain.trim;
+
+import com.h2o.h2oServer.domain.trim.entity.ExternalColorEntity;
+
+import java.util.List;
+
+public class ExternalColorFixture {
+    public static List<ExternalColorEntity> generateExternalColorEntityList() {
+        return List.of(
+                ExternalColorEntity.builder()
+                        .id(1L)
+                        .name("Red")
+                        .colorCode("#FF0000")
+                        .choiceRatio(0.5F)
+                        .price(100)
+                        .build(),
+                ExternalColorEntity.builder()
+                        .id(2L)
+                        .name("Black")
+                        .colorCode("#FF0001")
+                        .choiceRatio(0.2F)
+                        .price(240)
+                        .build());
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/ImageFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/ImageFixture.java
@@ -1,0 +1,20 @@
+package com.h2o.h2oServer.domain.trim;
+
+import com.h2o.h2oServer.domain.trim.entity.ImageEntity;
+
+import java.util.List;
+
+public class ImageFixture {
+    public static List<ImageEntity> generateImageEntityList() {
+        return List.of(
+                ImageEntity.builder()
+                        .image("url1")
+                        .id(1L)
+                        .build(),
+                ImageEntity.builder()
+                        .image("url2")
+                        .id(2L)
+                        .build()
+        );
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/InternalColorFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/InternalColorFixture.java
@@ -1,0 +1,28 @@
+package com.h2o.h2oServer.domain.trim;
+
+import com.h2o.h2oServer.domain.trim.entity.InternalColorEntity;
+
+import java.util.List;
+
+public class InternalColorFixture {
+    public static List<InternalColorEntity> generateInernalColorEntityList() {
+        return List.of(
+                InternalColorEntity.builder()
+                        .id(1L)
+                        .choiceRatio(0.3f)
+                        .price(2000)
+                        .fabricImage("fabric_image_url_1")
+                        .internalImage("internal_image_url_1")
+                        .name("Red")
+                        .build(),
+                InternalColorEntity.builder()
+                        .id(2L)
+                        .choiceRatio(0.2f)
+                        .price(1500)
+                        .fabricImage("fabric_image_url_2")
+                        .internalImage("internal_image_url_2")
+                        .name("Blue")
+                        .build()
+        );
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/TrimFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/TrimFixture.java
@@ -1,0 +1,46 @@
+package com.h2o.h2oServer.domain.trim;
+
+import com.h2o.h2oServer.domain.trim.entity.TrimEntity;
+
+import java.util.List;
+
+public class TrimFixture {
+    public static List<TrimEntity> generateTrimEntityList() {
+        return List.of(
+                TrimEntity.builder()
+                        .id(1L)
+                        .name("Trim A")
+                        .description("Description of Trim A")
+                        .price(50000)
+                        .carId(1L)
+                        .build(),
+                TrimEntity.builder()
+                        .id(2L)
+                        .name("Trim B")
+                        .description("Description of Trim b")
+                        .price(70000)
+                        .carId(1L)
+                        .build()
+        );
+    }
+
+    public static TrimEntity generateTrimEntity(long carId) {
+        return TrimEntity.builder()
+                .id(1L)
+                .name("Trim A")
+                .description("Description of Trim A")
+                .price(50000)
+                .carId(carId)
+                .build();
+    }
+
+    public static TrimEntity generateTrimEntity() {
+        return TrimEntity.builder()
+                .id(1L)
+                .name("Trim A")
+                .description("Description of Trim A")
+                .price(50000)
+                .carId(1L)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/api/TrimControllerTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/api/TrimControllerTest.java
@@ -5,13 +5,15 @@ import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(TrimController.class)
+@WebMvcTest(controllers = TrimController.class)
 class TrimControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+    @MockBean
     private TrimService trimService;
 
     @BeforeEach
@@ -19,21 +21,16 @@ class TrimControllerTest {
         trimService = Mockito.mock(TrimService.class);
     }
 
-//    @Nested
-//    @DisplayName("트림 정보 조회 테스트")
-//    class getTrimInformationTest {
+    @Nested
+    @DisplayName("트림 정보 조회 테스트")
+    class getTrimInformationTest {
 
-//        @Test
-//        @DisplayName("존재하는 trim 요청에 대해서 유효한 값을 갖는 TrimDto를 응답한다.")
-//        void withValidTrimId() {
-//            //given
-////            mockMvc.perform(MockMvcRequestBuilders.get("car/{carId}/trim", 2L))
-////                    .andExpect(MockMvcResultMatchers.status().isOk())
-////                    .andExpect(MockMvcResultMatchers.content().string("Expected Response Body"));
-//            //when
-//
-//            //then
-//        }
-//    }
-
+        @Test
+        @DisplayName("존재하는 trim 요청에 대해서 유효한 값을 갖는 TrimDto를 응답한다.")
+        void withValidTrimId() throws Exception {
+            //given
+            //when
+            //then
+        }
+    }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/api/TrimControllerTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/api/TrimControllerTest.java
@@ -1,0 +1,39 @@
+package com.h2o.h2oServer.domain.trim.api;
+
+import com.h2o.h2oServer.domain.trim.application.TrimService;
+import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TrimController.class)
+class TrimControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    private TrimService trimService;
+
+    @BeforeEach
+    void setup() {
+        trimService = Mockito.mock(TrimService.class);
+    }
+
+//    @Nested
+//    @DisplayName("트림 정보 조회 테스트")
+//    class getTrimInformationTest {
+
+//        @Test
+//        @DisplayName("존재하는 trim 요청에 대해서 유효한 값을 갖는 TrimDto를 응답한다.")
+//        void withValidTrimId() {
+//            //given
+////            mockMvc.perform(MockMvcRequestBuilders.get("car/{carId}/trim", 2L))
+////                    .andExpect(MockMvcResultMatchers.status().isOk())
+////                    .andExpect(MockMvcResultMatchers.content().string("Expected Response Body"));
+//            //when
+//
+//            //then
+//        }
+//    }
+
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/application/TrimServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/application/TrimServiceTest.java
@@ -12,6 +12,8 @@ import com.h2o.h2oServer.domain.trim.mapper.ExternalColorMapper;
 import com.h2o.h2oServer.domain.trim.mapper.TrimMapper;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -47,141 +49,168 @@ class TrimServiceTest {
         softly = new SoftAssertions();
     }
 
-    @BeforeEach
-    void setUp() {
-    }
+    @Nested
+    @DisplayName("트림 정보 조회 테스트")
+    class findTrimInformationTest {
+        @Test
+        @DisplayName("존재하는 car에 대한 요청인 경우 Dto로 formatting해서 반환한다.")
+        void findTrimInformation() {
+            //given
+            Long carId = 1L;
+            when(trimMapper.findByCarId(carId)).thenReturn(generateTrimEntityList());
+            when(trimMapper.findOptionStatistics(1L)).thenReturn(generateOptionStatisticsList());
+            when(trimMapper.findOptionStatistics(2L)).thenReturn(generateOptionStatisticsList());
+            when(trimMapper.findImages(1L)).thenReturn(generateImageEntityList());
+            when(trimMapper.findImages(2L)).thenReturn(generateImageEntityList());
 
-    @Test
-    @DisplayName("존재하는 car에 대한 요청인 경우 Dto로 formatting해서 반환한다.")
-    void findTrimInformation() {
-        //given
-        Long carId = 1L;
-        when(trimMapper.findByCarId(carId)).thenReturn(generateTrimEntityList());
-        when(trimMapper.findOptionStatistics(1L)).thenReturn(generateOptionStatisticsList());
-        when(trimMapper.findOptionStatistics(2L)).thenReturn(generateOptionStatisticsList());
-        when(trimMapper.findImages(1L)).thenReturn(generateImageEntityList());
-        when(trimMapper.findImages(2L)).thenReturn(generateImageEntityList());
+            //when
+            List<TrimDto> actualTrimDtos = trimService.findTrimInformation(carId);
 
-        //when
-        List<TrimDto> actualTrimDtos = trimService.findTrimInformation(carId);
-
-        //then
-        softly.assertThat(actualTrimDtos).as("null이 아니다.").isNotNull();
-        softly.assertThat(actualTrimDtos).as("TrimDto를 포함한다.").isNotEmpty();
-        softly.assertThat(actualTrimDtos.get(0).getImages()).as("Images를 포함한다.").isNotNull();
-        softly.assertThat(actualTrimDtos.get(0).getOptions()).as("Options를 포함한다.").isNotNull();
-        softly.assertAll();
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 차량에 대한 요청인 경우 NoSuchTrimException을 발생시킨다.")
-    void findTrimInformationNotExist() {
-        //given
-        Long carId = Long.MAX_VALUE;
-        when(trimMapper.findByCarId(carId)).thenReturn(List.of());
-
-        //when
-        //then
-        assertThatThrownBy(() -> trimService.findTrimInformation(carId))
-                .isInstanceOf(NoSuchTrimException.class);
-    }
-
-    @Test
-    @DisplayName("존재하는 externalColor에 대한 요청인 경우, Dto로 포매팅해서 반환한다.")
-    void findExternalColorInformation() {
-        //given
-        Long trimId = 1L;
-        when(trimMapper.findExternalColor(trimId)).thenReturn(generateExternalColorEntityList());
-        when(externalColorMapper.findImages(1L)).thenReturn(generateImageEntityList());
-        when(externalColorMapper.findImages(2L)).thenReturn(generateImageEntityList());
-
-        //when
-        List<ExternalColorDto> actualExternalColorDtos = trimService.findExternalColorInformation(trimId);
-
-        //then
-        softly.assertThat(actualExternalColorDtos).as("null이 아니다.").isNotNull();
-        softly.assertThat(actualExternalColorDtos).as("ExternalColorDtos를 두 개 포함한다.").hasSize(2);
-        softly.assertThat(actualExternalColorDtos.get(0).getImages()).as("Images를 포함한다.").isNotNull();
-        softly.assertThat(actualExternalColorDtos.get(0).getName()).as("name 필드를 포함한다.").isNotNull();
-        softly.assertAll();
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 externalColor에 대한 요청인 경우, NoSuchTrimException을 발생시킨다.")
-    void findExternalColorInformationNotExist() {
-        //given
-        Long trimId = 1L;
-        when(trimMapper.findExternalColor(trimId)).thenReturn(List.of());
-
-        //when
-        //then
-        assertThatThrownBy(() -> trimService.findExternalColorInformation(trimId))
-                .isInstanceOf(NoSuchTrimException.class);
-    }
-
-    @Test
-    @DisplayName("trimId에 해당하는 internalColor를 Dto로 포매팅해서 반환한다.")
-    void findInternalColorInformation() {
-        //given
-        Long trimId = 1L;
-        when(trimMapper.findInternalColor(trimId)).thenReturn(generateInernalColorEntityList());
-
-        //when
-        List<InternalColorDto> actualInternalColorDtos = trimService.findInternalColorInformation(trimId);
-
-        //then
-        softly.assertThat(actualInternalColorDtos).as("null이 아니다.")
-                .isNotNull();
-        softly.assertThat(actualInternalColorDtos).as("입력받은 entity의 개수만큼 dto를 담고 있다.")
-                .hasSize(2);
-        softly.assertThat(actualInternalColorDtos.get(0).getName()).as("입력받은 entity의 정보를 가지고 있다.")
-                .isEqualTo("Red");
-        softly.assertThat(actualInternalColorDtos.get(1).getName()).as("입력받은 entity의 정보를 가지고 있다.")
-                .isEqualTo("Blue");
-    }
-
-    @Test
-    @DisplayName("트림의 가격 범위를 반환한다.")
-    void findPriceRange() {
-        //given
-        Long trimId = 1L;
-        long carId = 1L;
-        when(trimMapper.findById(trimId)).thenReturn(generateTrimEntity(carId));
-        when(trimMapper.findMaximumComponentPrice(trimId)).thenReturn(20000);
-        when(carMapper.findMaximumModelTypePrice(carId)).thenReturn(10000);
-        when(carMapper.findMinimumModelTypePrice(carId)).thenReturn(0);
-        PriceRangeDto expectedPriceRange = PriceRangeDto.of(20000 + 50000 + 10000, 50000);
-
-        //when
-        PriceRangeDto actualPriceRange = trimService.findPriceRange(trimId);
-
-        //then
-        assertThat(actualPriceRange).isEqualTo(expectedPriceRange);
-    }
-
-    @Test
-    @DisplayName("존재하는 가격 범위 내의 분포 정보를 dto로 반환한다.")
-    void findAndScalePriceDistribution() {
-        //given
-        Long trimId = 1L;
-        Long carId = 1L;
-        when(trimMapper.findById(trimId)).thenReturn(generateTrimEntity(carId));
-        when(trimMapper.findMaximumComponentPrice(trimId)).thenReturn(5000000);
-        when(carMapper.findMaximumModelTypePrice(carId)).thenReturn(5000000);
-        when(carMapper.findMinimumModelTypePrice(carId)).thenReturn(0);
-        int unit = 10000000 / 30;
-
-        for (int index = 0; index < 30; index++) {
-            when(trimMapper.findQuantityBetween(trimId, 50000 + unit * index, 50000 + unit * (index + 1))).thenReturn(5);
+            //then
+            softly.assertThat(actualTrimDtos).as("null이 아니다.").isNotNull();
+            softly.assertThat(actualTrimDtos).as("TrimDto를 포함한다.").isNotEmpty();
+            softly.assertThat(actualTrimDtos.get(0).getImages()).as("Images를 포함한다.").isNotNull();
+            softly.assertThat(actualTrimDtos.get(0).getOptions()).as("Options를 포함한다.").isNotNull();
+            softly.assertAll();
         }
 
-        //when
-        PriceDistributionDto actualDto = trimService.findAndScalePriceDistribution(trimId);
+        @Test
+        @DisplayName("존재하지 않는 차량에 대한 요청인 경우 NoSuchTrimException을 발생시킨다.")
+        void findTrimInformationNotExist() {
+            //given
+            Long carId = Long.MAX_VALUE;
+            when(trimMapper.findByCarId(carId)).thenReturn(List.of());
 
-        //then
-        softly.assertThat(actualDto.getUnit()).isEqualTo(unit);
-        softly.assertThat(actualDto.getQuantityPerUnit()).hasSize(30);
-        softly.assertThat(actualDto.getQuantityPerUnit()).allMatch(quantity -> quantity == 5);
-        softly.assertAll();
+            //when
+            //then
+            assertThatThrownBy(() -> trimService.findTrimInformation(carId))
+                    .isInstanceOf(NoSuchTrimException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("색상 정보 조회 테스트")
+    class findColorInformationTest {
+        @Test
+        @DisplayName("존재하는 externalColor에 대한 요청인 경우, Dto로 포매팅해서 반환한다.")
+        void findExternalColorInformation() {
+            //given
+            Long trimId = 1L;
+            when(trimMapper.findExternalColor(trimId)).thenReturn(generateExternalColorEntityList());
+            when(externalColorMapper.findImages(1L)).thenReturn(generateImageEntityList());
+            when(externalColorMapper.findImages(2L)).thenReturn(generateImageEntityList());
+
+            //when
+            List<ExternalColorDto> actualExternalColorDtos = trimService.findExternalColorInformation(trimId);
+
+            //then
+            softly.assertThat(actualExternalColorDtos).as("ExternalColorDtos를 두 개 포함한다.").hasSize(2);
+            softly.assertThat(actualExternalColorDtos.get(0).getImages()).as("Images를 포함한다.").isNotNull();
+            softly.assertThat(actualExternalColorDtos.get(0).getName()).as("name 필드를 포함한다.").isNotNull();
+            softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 externalColor에 대한 요청인 경우, NoSuchTrimException을 발생시킨다.")
+        void findExternalColorInformationNotExist() {
+            //given
+            Long trimId = 1L;
+            when(trimMapper.findExternalColor(trimId)).thenReturn(List.of());
+
+            //when
+            //then
+            assertThatThrownBy(() -> trimService.findExternalColorInformation(trimId))
+                    .isInstanceOf(NoSuchTrimException.class);
+        }
+
+        @Test
+        @DisplayName("trimId에 해당하는 internalColor를 Dto로 포매팅해서 반환한다.")
+        void findInternalColorInformation() {
+            //given
+            Long trimId = 1L;
+            when(trimMapper.findInternalColor(trimId)).thenReturn(generateInernalColorEntityList());
+
+            //when
+            List<InternalColorDto> actualInternalColorDtos = trimService.findInternalColorInformation(trimId);
+
+            //then
+            softly.assertThat(actualInternalColorDtos).as("입력받은 entity의 개수만큼 dto를 담고 있다.")
+                    .hasSize(2);
+            softly.assertThat(actualInternalColorDtos.get(0).getName()).as("입력받은 entity의 정보를 가지고 있다.")
+                    .isEqualTo("Red");
+            softly.assertThat(actualInternalColorDtos.get(1).getName()).as("입력받은 entity의 정보를 가지고 있다.")
+                    .isEqualTo("Blue");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 internalColor에 대한 요청인 경우, NoSuchTrimException을 발생시킨다.")
+        void findInternalColorInformationNotExist() {
+            //given
+            Long trimId = 1L;
+            when(trimMapper.findInternalColor(trimId)).thenReturn(List.of());
+
+            //when
+            //then
+            assertThatThrownBy(() -> trimService.findInternalColorInformation(trimId))
+                    .isInstanceOf(NoSuchTrimException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("트림 가격 분포 테스트")
+    class PriceDistributionTest {
+        @ParameterizedTest
+        @DisplayName("트림의 가격 범위를 반환한다.")
+        @CsvSource({
+                "20000, 10000, 0",
+                "15000, 5000, 0",
+                "25000, 15000, 5000"
+        })
+        void findPriceRange(int maxComponentPrice, int maxModeltypePrice, int minModeltypePrice) {
+            //given
+            Long trimId = 1L;
+            long carId = 1L;
+            int trimPrice = 50000;
+
+            when(trimMapper.findById(trimId)).thenReturn(generateTrimEntity(carId));
+            when(trimMapper.findMaximumComponentPrice(trimId)).thenReturn(maxComponentPrice);
+            when(carMapper.findMaximumModelTypePrice(carId)).thenReturn(maxModeltypePrice);
+            when(carMapper.findMinimumModelTypePrice(carId)).thenReturn(minModeltypePrice);
+
+            PriceRangeDto expectedPriceRange = PriceRangeDto.of(maxComponentPrice + trimPrice + maxModeltypePrice,
+                    trimPrice + minModeltypePrice);
+
+            //when
+            PriceRangeDto actualPriceRange = trimService.findPriceRange(trimId);
+
+            //then
+            assertThat(actualPriceRange).isEqualTo(expectedPriceRange);
+        }
+
+        @Test
+        @DisplayName("존재하는 가격 범위 내의 분포 정보를 dto로 반환한다.")
+        void findAndScalePriceDistribution() {
+            //given
+            Long trimId = 1L;
+            Long carId = 1L;
+            when(trimMapper.findById(trimId)).thenReturn(generateTrimEntity(carId));
+            when(trimMapper.findMaximumComponentPrice(trimId)).thenReturn(5000000);
+            when(carMapper.findMaximumModelTypePrice(carId)).thenReturn(5000000);
+            when(carMapper.findMinimumModelTypePrice(carId)).thenReturn(0);
+            int unit = 10000000 / 30;
+
+            for (int index = 0; index < 30; index++) {
+                when(trimMapper.findQuantityBetween(trimId, 50000 + unit * index, 50000 + unit * (index + 1))).thenReturn(5);
+            }
+
+            //when
+            PriceDistributionDto actualDto = trimService.findAndScalePriceDistribution(trimId);
+
+            //then
+            softly.assertThat(actualDto.getUnit()).isEqualTo(unit);
+            softly.assertThat(actualDto.getQuantityPerUnit()).hasSize(30);
+            softly.assertThat(actualDto.getQuantityPerUnit()).allMatch(quantity -> quantity == 5);
+            softly.assertAll();
+        }
     }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/application/TrimServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/application/TrimServiceTest.java
@@ -8,13 +8,8 @@ import com.h2o.h2oServer.domain.trim.dto.InternalColorDto;
 import com.h2o.h2oServer.domain.trim.dto.PriceRangeDto;
 import com.h2o.h2oServer.domain.trim.dto.TrimDto;
 import com.h2o.h2oServer.domain.trim.dto.*;
-import com.h2o.h2oServer.domain.trim.entity.ExternalColorEntity;
-import com.h2o.h2oServer.domain.trim.entity.ImageEntity;
-import com.h2o.h2oServer.domain.trim.entity.OptionStatisticsEntity;
-import com.h2o.h2oServer.domain.trim.entity.TrimEntity;
 import com.h2o.h2oServer.domain.trim.mapper.ExternalColorMapper;
 import com.h2o.h2oServer.domain.trim.mapper.TrimMapper;
-import com.h2o.h2oServer.domain.trim.entity.InternalColorEntity;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
@@ -22,6 +17,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
+import static com.h2o.h2oServer.domain.option.OptionFixture.generateOptionStatisticsList;
+import static com.h2o.h2oServer.domain.trim.ExternalColorFixture.generateExternalColorEntityList;
+import static com.h2o.h2oServer.domain.trim.ImageFixture.generateImageEntityList;
+import static com.h2o.h2oServer.domain.trim.InternalColorFixture.generateInernalColorEntityList;
+import static com.h2o.h2oServer.domain.trim.TrimFixture.generateTrimEntity;
+import static com.h2o.h2oServer.domain.trim.TrimFixture.generateTrimEntityList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
@@ -118,69 +119,6 @@ class TrimServiceTest {
                 .isInstanceOf(NoSuchTrimException.class);
     }
 
-    private static List<ExternalColorEntity> generateExternalColorEntityList() {
-        return List.of(
-                ExternalColorEntity.builder()
-                        .id(1L)
-                        .name("Red")
-                        .colorCode("#FF0000")
-                        .choiceRatio(0.5F)
-                        .price(100)
-                        .build(),
-                ExternalColorEntity.builder()
-                        .id(2L)
-                        .name("Black")
-                        .colorCode("#FF0001")
-                        .choiceRatio(0.2F)
-                        .price(240)
-                        .build());
-    }
-
-    private static List<ImageEntity> generateImageEntityList() {
-        return List.of(
-                ImageEntity.builder()
-                        .image("url1")
-                        .id(1L)
-                        .build(),
-                ImageEntity.builder()
-                        .image("url2")
-                        .id(2L)
-                        .build()
-        );
-    }
-
-    private List<OptionStatisticsEntity> generateOptionStatisticsList() {
-        return List.of(
-                OptionStatisticsEntity.builder()
-                        .id(1L)
-                        .name("Option A")
-                        .useCount(0.75F)
-                        .build(),
-                OptionStatisticsEntity.builder()
-                        .id(2L)
-                        .name("Option B")
-                        .useCount(0.5F)
-                        .build()
-        );
-    }
-
-    private List<TrimEntity> generateTrimEntityList() {
-        return List.of(
-                TrimEntity.builder()
-                        .id(1L)
-                        .name("Trim A")
-                        .description("Description of Trim A")
-                        .price(50000)
-                        .build(),
-                TrimEntity.builder()
-                        .id(2L)
-                        .name("Trim B")
-                        .description("Description of Trim b")
-                        .price(70000)
-                        .build()
-        );
-    }
-
     @Test
     @DisplayName("trimId에 해당하는 internalColor를 Dto로 포매팅해서 반환한다.")
     void findInternalColorInformation() {
@@ -202,27 +140,6 @@ class TrimServiceTest {
                 .isEqualTo("Blue");
     }
 
-    private List<InternalColorEntity> generateInernalColorEntityList() {
-        return List.of(
-                InternalColorEntity.builder()
-                        .id(1L)
-                        .choiceRatio(0.3f)
-                        .price(2000)
-                        .fabricImage("fabric_image_url_1")
-                        .internalImage("internal_image_url_1")
-                        .name("Red")
-                        .build(),
-                InternalColorEntity.builder()
-                        .id(2L)
-                        .choiceRatio(0.2f)
-                        .price(1500)
-                        .fabricImage("fabric_image_url_2")
-                        .internalImage("internal_image_url_2")
-                        .name("Blue")
-                        .build()
-        );
-    }
-
     @Test
     @DisplayName("트림의 가격 범위를 반환한다.")
     void findPriceRange() {
@@ -233,7 +150,7 @@ class TrimServiceTest {
         when(trimMapper.findMaximumComponentPrice(trimId)).thenReturn(20000);
         when(carMapper.findMaximumModelTypePrice(carId)).thenReturn(10000);
         when(carMapper.findMinimumModelTypePrice(carId)).thenReturn(0);
-        PriceRangeDto expectedPriceRange = PriceRangeDto.of(20000 + 30000000 + 10000, 30000000);
+        PriceRangeDto expectedPriceRange = PriceRangeDto.of(20000 + 50000 + 10000, 50000);
 
         //when
         PriceRangeDto actualPriceRange = trimService.findPriceRange(trimId);
@@ -255,7 +172,7 @@ class TrimServiceTest {
         int unit = 10000000 / 30;
 
         for (int index = 0; index < 30; index++) {
-            when(trimMapper.findQuantityBetween(trimId, 30000000 + unit * index, 30000000 + unit * (index + 1))).thenReturn(5);
+            when(trimMapper.findQuantityBetween(trimId, 50000 + unit * index, 50000 + unit * (index + 1))).thenReturn(5);
         }
 
         //when
@@ -266,15 +183,5 @@ class TrimServiceTest {
         softly.assertThat(actualDto.getQuantityPerUnit()).hasSize(30);
         softly.assertThat(actualDto.getQuantityPerUnit()).allMatch(quantity -> quantity == 5);
         softly.assertAll();
-    }
-
-    private static TrimEntity generateTrimEntity(long carId) {
-        return TrimEntity.builder()
-                .id(1L)
-                .name("Trim A")
-                .description("Description of Trim A")
-                .price(30000000)
-                .carId(carId)
-                .build();
     }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/ExternalColorMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/ExternalColorMapperTest.java
@@ -25,9 +25,8 @@ class ExternalColorMapperTest {
         softly = new SoftAssertions();
     }
 
-
     @Test
-    @DisplayName("존재하는 외부 색상에 대해서, 해당하는 정보를 ImageEntity로 반환한다.")
+    @DisplayName("존재하는 외부 색상에 대해서 해당하는 정보를 ImageEntity로 반환한다.")
     @Sql("classpath:db/image-data.sql")
     void findImages() {
         //given
@@ -38,7 +37,6 @@ class ExternalColorMapperTest {
         List<ImageEntity> actualImageEntities = externalColorMapper.findImages(externalColorId);
 
         //then
-        softly.assertThat(actualImageEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
         softly.assertThat(actualImageEntities).as("유효한 데이터만 매핑되었는지 확인").hasSize(2);
         softly.assertThat(actualImageEntities).as("externalColorId에 해당하는 객체가 모두 매핑되었는지 확인")
                 .containsAll(expectedImageEntities);

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/ExternalColorMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/ExternalColorMapperTest.java
@@ -1,5 +1,6 @@
 package com.h2o.h2oServer.domain.trim.mapper;
 
+import com.h2o.h2oServer.domain.trim.ImageFixture;
 import com.h2o.h2oServer.domain.trim.entity.ImageEntity;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,15 +32,7 @@ class ExternalColorMapperTest {
     void findImages() {
         //given
         Long externalColorId = 1L;
-        ImageEntity expectedImageEntity1 = ImageEntity.builder()
-                .image("image_url_1")
-                .id(1L)
-                .build();
-        ImageEntity expectedImageEntity2 = ImageEntity.builder()
-                .image("image_url_2")
-                .id(2L)
-                .build();
-
+        List<ImageEntity> expectedImageEntities = ImageFixture.generateImageEntityList();
 
         //when
         List<ImageEntity> actualImageEntities = externalColorMapper.findImages(externalColorId);
@@ -48,8 +41,8 @@ class ExternalColorMapperTest {
         softly.assertThat(actualImageEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
         softly.assertThat(actualImageEntities).as("유효한 데이터만 매핑되었는지 확인").hasSize(2);
         softly.assertThat(actualImageEntities).as("externalColorId에 해당하는 객체가 모두 매핑되었는지 확인")
-                .contains(expectedImageEntity1)
-                .contains(expectedImageEntity2);
+                .containsAll(expectedImageEntities);
+
         softly.assertAll();
     }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
@@ -1,5 +1,7 @@
 package com.h2o.h2oServer.domain.trim.mapper;
 
+import com.h2o.h2oServer.domain.trim.ExternalColorFixture;
+import com.h2o.h2oServer.domain.trim.TrimFixture;
 import com.h2o.h2oServer.domain.trim.entity.ExternalColorEntity;
 import com.h2o.h2oServer.domain.trim.entity.InternalColorEntity;
 import com.h2o.h2oServer.domain.trim.entity.TrimEntity;
@@ -32,13 +34,7 @@ class TrimMapperTest {
     void findById() {
         //given
         Long targetId = 1L;
-        TrimEntity expectedTrimEntity = TrimEntity.builder()
-                .id(targetId)
-                .name("Trim 1")
-                .description("Basic Trim")
-                .price(1500)
-                .carId(1L)
-                .build();
+        TrimEntity expectedTrimEntity = TrimFixture.generateTrimEntity();
 
         //when
         TrimEntity actualTrimEntity = trimMapper.findById(targetId);
@@ -69,6 +65,7 @@ class TrimMapperTest {
     void findByCarId() {
         //given
         Long targetCarId = 1L;
+        List<TrimEntity> expectedTrimEntities = TrimFixture.generateTrimEntityList();
         TrimEntity expectedTrimEntity1 = TrimEntity.builder()
                 .id(1L)
                 .name("Trim 1")
@@ -91,8 +88,7 @@ class TrimMapperTest {
         softly.assertThat(actualTrimEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
         softly.assertThat(actualTrimEntities).as("유효한 데이터만 매핑되었는지 확인").hasSize(2);
         softly.assertThat(actualTrimEntities).as("CarId에 해당하는 trim 객체가 모두 매핑되었는지 확인")
-                .contains(expectedTrimEntity1)
-                .contains(expectedTrimEntity2);
+                .containsAll(expectedTrimEntities);
         softly.assertAll();
     }
 
@@ -130,20 +126,7 @@ class TrimMapperTest {
     void findExternalColor() {
         //given
         Long trimId = 1L;
-        ExternalColorEntity expectedExternalColorEntity1 = ExternalColorEntity.builder()
-                .colorCode("#FF0000")
-                .choiceRatio(0.3f)
-                .id(1L)
-                .name("Red")
-                .price(2000)
-                .build();
-        ExternalColorEntity expectedExternalColorEntity2 = ExternalColorEntity.builder()
-                .colorCode("#0000FF")
-                .choiceRatio(0.5f)
-                .id(2L)
-                .name("Blue")
-                .price(1800)
-                .build();
+        List<ExternalColorEntity> expectedExternalColorEntities = ExternalColorFixture.generateExternalColorEntityList();
 
         //when
         List<ExternalColorEntity> actualExternalColorEntities = trimMapper.findExternalColor(trimId);
@@ -152,8 +135,7 @@ class TrimMapperTest {
         assertThat(actualExternalColorEntities).as("유효한 데이터가 매핑된다.").isNotEmpty();
         assertThat(actualExternalColorEntities).as("유효한 데이터가 매핑된다.").hasSize(2);
         softly.assertThat(actualExternalColorEntities).as("trimId에 해당하는 externalColorEntity 객체가 모두 매핑되었는지 확인")
-                .contains(expectedExternalColorEntity1)
-                .contains(expectedExternalColorEntity2);
+                .containsAll(expectedExternalColorEntities);
         softly.assertAll();
     }
 

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
@@ -1,6 +1,7 @@
 package com.h2o.h2oServer.domain.trim.mapper;
 
 import com.h2o.h2oServer.domain.trim.ExternalColorFixture;
+import com.h2o.h2oServer.domain.trim.InternalColorFixture;
 import com.h2o.h2oServer.domain.trim.TrimFixture;
 import com.h2o.h2oServer.domain.trim.entity.ExternalColorEntity;
 import com.h2o.h2oServer.domain.trim.entity.InternalColorEntity;
@@ -66,20 +67,6 @@ class TrimMapperTest {
         //given
         Long targetCarId = 1L;
         List<TrimEntity> expectedTrimEntities = TrimFixture.generateTrimEntityList();
-        TrimEntity expectedTrimEntity1 = TrimEntity.builder()
-                .id(1L)
-                .name("Trim 1")
-                .description("Basic Trim")
-                .price(1500)
-                .carId(1L)
-                .build();
-        TrimEntity expectedTrimEntity2 = TrimEntity.builder()
-                .id(2L)
-                .name("Trim 2")
-                .description("Advanced Trim")
-                .price(2500)
-                .carId(1L)
-                .build();
 
         //when
         List<TrimEntity> actualTrimEntities = trimMapper.findByCarId(targetCarId);
@@ -145,22 +132,7 @@ class TrimMapperTest {
     void findInternalColor() {
         //given
         Long trimId = 1L;
-        InternalColorEntity expectEntity1 = InternalColorEntity.builder()
-                .id(1L)
-                .choiceRatio(0.3f)
-                .price(2000)
-                .fabricImage("fabric_image_url_1")
-                .internalImage("internal_image_url_1")
-                .name("Red")
-                .build();
-        InternalColorEntity expectEntity2 = InternalColorEntity.builder()
-                .id(2L)
-                .choiceRatio(0.2f)
-                .price(1500)
-                .fabricImage("fabric_image_url_2")
-                .internalImage("internal_image_url_2")
-                .name("Blue")
-                .build();
+        List<InternalColorEntity> expectedInternalColorEntities = InternalColorFixture.generateInernalColorEntityList();
 
         //when
         List<InternalColorEntity> actualEntities = trimMapper.findInternalColor(trimId);
@@ -169,8 +141,7 @@ class TrimMapperTest {
         softly.assertThat(actualEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
         softly.assertThat(actualEntities).as("유효한 데이터만 매핑되었는지 확인").hasSize(2);
         softly.assertThat(actualEntities).as("trimId에 해당하는 InternalColorEntity 객체가 모두 매핑되었는지 확인")
-                .contains(expectEntity1)
-                .contains(expectEntity2);
+                .containsAll(expectedInternalColorEntities);
         softly.assertAll();
     }
 

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
@@ -29,68 +29,140 @@ class TrimMapperTest {
         softly = new SoftAssertions();
     }
 
-    @Test
-    @DisplayName("존재하는 회원에 대해서, 해당하는 row를 Trim 객체에 담아 반환한다.")
-    @Sql("classpath:db/trim/trims-data.sql")
-    void findById() {
-        //given
-        Long targetId = 1L;
-        TrimEntity expectedTrimEntity = TrimFixture.generateTrimEntity();
+    @Nested
+    @DisplayName("트림 검색 테스트")
+    class FindTest {
+        @Test
+        @DisplayName("존재하는 회원에 대해서, 해당하는 row를 Trim 객체에 담아 반환한다.")
+        @Sql("classpath:db/trim/trims-data.sql")
+        void findById() {
+            //given
+            Long targetId = 1L;
+            TrimEntity expectedTrimEntity = TrimFixture.generateTrimEntity();
 
-        //when
-        TrimEntity actualTrimEntity = trimMapper.findById(targetId);
+            //when
+            TrimEntity actualTrimEntity = trimMapper.findById(targetId);
 
-        //then
-        softly.assertThat(actualTrimEntity).as("유효한 데이터가 매핑되었는지 확인").isNotNull();
-        softly.assertThat(actualTrimEntity).as("데이터베이스에 존재하는 데이터인지 확인").isEqualTo(expectedTrimEntity);
-        softly.assertAll();
+            //then
+            softly.assertThat(actualTrimEntity).as("데이터베이스에 존재하는 데이터인지 확인").isEqualTo(expectedTrimEntity);
+            softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 트림에 대해서는 null을 반환한다.")
+        @Sql("classpath:db/trim/trims-data.sql")
+        void findByIdWithoutResult() {
+            //given
+            Long targetId = Long.MAX_VALUE;
+
+            //when
+            TrimEntity actualTrimEntity = trimMapper.findById(targetId);
+
+            //then
+            assertThat(actualTrimEntity).isNull();
+        }
+
+        @Test
+        @DisplayName("존재하는 회원에 대해서, 해당하는 row를 Trim 객체에 담아 반환한다.")
+        @Sql("classpath:db/trim/trims-data.sql")
+        void findByCarId() {
+            //given
+            Long targetCarId = 1L;
+            List<TrimEntity> expectedTrimEntities = TrimFixture.generateTrimEntityList();
+
+            //when
+            List<TrimEntity> actualTrimEntities = trimMapper.findByCarId(targetCarId);
+
+            //then
+            softly.assertThat(actualTrimEntities).as("유효한 데이터만 매핑되었는지 확인").hasSize(2);
+            softly.assertThat(actualTrimEntities).as("CarId에 해당하는 trim 객체가 모두 매핑되었는지 확인")
+                    .containsAll(expectedTrimEntities);
+            softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 차량에 대해서는 빈 배열을 반환한다.")
+        @Sql("classpath:db/trim/trims-data.sql")
+        void findByCarIdWithoutResult() {
+            //given
+            Long targetCarId = Long.MAX_VALUE;
+
+            //when
+            List<TrimEntity> actualTrimEntities = trimMapper.findByCarId(targetCarId);
+
+            //then
+            assertThat(actualTrimEntities).isEmpty();
+        }
     }
 
-    @Test
-    @DisplayName("존재하지 않는 회원에 대해서는 null을 반환한다.")
-    @Sql("classpath:db/trim/trims-data.sql")
-    void findByIdWithoutResult() {
-        //given
-        Long targetId = Long.MAX_VALUE;
+    @Nested
+    @DisplayName("색상 조회 테스트")
+    class FindColorTest {
+        @Test
+        @DisplayName("존재하는 trim에 대한 외부 색상 요청일 경우 externalColorEntity를 반환한다.")
+        @Sql("classpath:db/trim/external-color-data.sql")
+        void findExternalColor() {
+            //given
+            Long trimId = 1L;
+            List<ExternalColorEntity> expectedExternalColorEntities = ExternalColorFixture.generateExternalColorEntityList();
 
-        //when
-        TrimEntity actualTrimEntity = trimMapper.findById(targetId);
+            //when
+            List<ExternalColorEntity> actualExternalColorEntities = trimMapper.findExternalColor(trimId);
 
-        //then
-        assertThat(actualTrimEntity).isNull();
-    }
+            //then
+            assertThat(actualExternalColorEntities).as("유효한 데이터가 매핑된다.").isNotEmpty();
+            assertThat(actualExternalColorEntities).as("유효한 데이터가 매핑된다.").hasSize(2);
+            softly.assertThat(actualExternalColorEntities).as("trimId에 해당하는 externalColorEntity 객체가 모두 매핑되었는지 확인")
+                    .containsAll(expectedExternalColorEntities);
+            softly.assertAll();
+        }
 
-    @Test
-    @DisplayName("존재하는 회원에 대해서, 해당하는 row를 Trim 객체에 담아 반환한다.")
-    @Sql("classpath:db/trim/trims-data.sql")
-    void findByCarId() {
-        //given
-        Long targetCarId = 1L;
-        List<TrimEntity> expectedTrimEntities = TrimFixture.generateTrimEntityList();
+        @Test
+        @DisplayName("존재하지 않는 trim에 대해서는 빈 배열을 반환한다.")
+        @Sql("classpath:db/trim/trims-data.sql")
+        void findExternalColorNotExists() {
+            //given
+            Long trimId = Long.MAX_VALUE;
 
-        //when
-        List<TrimEntity> actualTrimEntities = trimMapper.findByCarId(targetCarId);
+            //when
+            List<ExternalColorEntity> actualExternalColorEntity = trimMapper.findExternalColor(trimId);
 
-        //then
-        softly.assertThat(actualTrimEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
-        softly.assertThat(actualTrimEntities).as("유효한 데이터만 매핑되었는지 확인").hasSize(2);
-        softly.assertThat(actualTrimEntities).as("CarId에 해당하는 trim 객체가 모두 매핑되었는지 확인")
-                .containsAll(expectedTrimEntities);
-        softly.assertAll();
-    }
+            //then
+            assertThat(actualExternalColorEntity).isEmpty();
+        }
 
-    @Test
-    @DisplayName("존재하지 않는 회원에 대해서는 null을 반환한다.")
-    @Sql("classpath:db/trim/trims-data.sql")
-    void findByCarIdWithoutResult() {
-        //given
-        Long targetCarId = Long.MAX_VALUE;
+        @Test
+        @DisplayName("존재하는 trim에 대한 내부 색상 요청일 경우 InternalColorEntity를 반환한다. ")
+        @Sql("classpath:db/trim/internal-color-data.sql")
+        void findInternalColor() {
+            //given
+            Long trimId = 1L;
+            List<InternalColorEntity> expectedInternalColorEntities = InternalColorFixture.generateInernalColorEntityList();
 
-        //when
-        List<TrimEntity> actualTrimEntities = trimMapper.findByCarId(targetCarId);
+            //when
+            List<InternalColorEntity> actualEntities = trimMapper.findInternalColor(trimId);
 
-        //then
-        assertThat(actualTrimEntities).isEmpty();
+            //then
+            softly.assertThat(actualEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
+            softly.assertThat(actualEntities).as("유효한 데이터만 매핑되었는지 확인").hasSize(2);
+            softly.assertThat(actualEntities).as("trimId에 해당하는 InternalColorEntity 객체가 모두 매핑되었는지 확인")
+                    .containsAll(expectedInternalColorEntities);
+            softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 trim에 대해서는 빈 배열을 반환한다.")
+        @Sql("classpath:db/trim/trims-data.sql")
+        void findInternalColorNotExists() {
+            //given
+            Long trimId = Long.MAX_VALUE;
+
+            //when
+            List<InternalColorEntity> actualInternalColorEntity = trimMapper.findInternalColor(trimId);
+
+            //then
+            assertThat(actualInternalColorEntity).isEmpty();
+        }
     }
 
     @Test
@@ -98,51 +170,13 @@ class TrimMapperTest {
     @Sql("classpath:db/trim/trims-data.sql")
     void findAll() {
         //given
-        Long expectedLength = 10L;
+        long expectedLength = 10L;
 
         //when
         List<TrimEntity> actualTrimEntities = trimMapper.findAll();
 
         //then
         assertThat(actualTrimEntities).as("db에 존재하는 row의 개수와 길이가 같은지 확인").hasSize(Math.toIntExact(expectedLength));
-    }
-
-    @Test
-    @DisplayName("유효한 trim에 대해서, externalColorEntity를 반환한다.")
-    @Sql("classpath:db/trim/external-color-data.sql")
-    void findExternalColor() {
-        //given
-        Long trimId = 1L;
-        List<ExternalColorEntity> expectedExternalColorEntities = ExternalColorFixture.generateExternalColorEntityList();
-
-        //when
-        List<ExternalColorEntity> actualExternalColorEntities = trimMapper.findExternalColor(trimId);
-
-        //then
-        assertThat(actualExternalColorEntities).as("유효한 데이터가 매핑된다.").isNotEmpty();
-        assertThat(actualExternalColorEntities).as("유효한 데이터가 매핑된다.").hasSize(2);
-        softly.assertThat(actualExternalColorEntities).as("trimId에 해당하는 externalColorEntity 객체가 모두 매핑되었는지 확인")
-                .containsAll(expectedExternalColorEntities);
-        softly.assertAll();
-    }
-
-    @Test
-    @DisplayName("존재하는 trimId에 대한 내부 색상 요청에 대해서 InternalColorEntity List를 반환한다. ")
-    @Sql("classpath:db/trim/internal-color-data.sql")
-    void findInternalColor() {
-        //given
-        Long trimId = 1L;
-        List<InternalColorEntity> expectedInternalColorEntities = InternalColorFixture.generateInernalColorEntityList();
-
-        //when
-        List<InternalColorEntity> actualEntities = trimMapper.findInternalColor(trimId);
-
-        //then
-        softly.assertThat(actualEntities).as("유효한 데이터가 매핑되었는지 확인").isNotEmpty();
-        softly.assertThat(actualEntities).as("유효한 데이터만 매핑되었는지 확인").hasSize(2);
-        softly.assertThat(actualEntities).as("trimId에 해당하는 InternalColorEntity 객체가 모두 매핑되었는지 확인")
-                .containsAll(expectedInternalColorEntities);
-        softly.assertAll();
     }
 
     @Test
@@ -160,32 +194,36 @@ class TrimMapperTest {
         assertThat(actualPrice).isEqualTo(expectedPrice);
     }
 
-    @Test
-    @DisplayName("존재하는 트림인 경우 true를 반환한다.")
-    @Sql("classpath:db/trim/trims-data.sql")
-    void checkIfTrimExists() {
-        //given
-        Long id = 1L;
+    @Nested
+    @DisplayName("존재 여부 확인 쿼리 테스트")
+    class checkIfTrimExistTest {
+        @Test
+        @DisplayName("존재하는 트림인 경우 true를 반환한다.")
+        @Sql("classpath:db/trim/trims-data.sql")
+        void checkIfTrimExists() {
+            //given
+            Long id = 1L;
 
-        //when
-        Boolean isExists = trimMapper.checkIfTrimExists(id);
+            //when
+            Boolean isExists = trimMapper.checkIfTrimExists(id);
 
-        //then
-        assertThat(isExists).isTrue();
-    }
+            //then
+            assertThat(isExists).isTrue();
+        }
 
-    @Test
-    @DisplayName("존재하지 않는 트림인 경우 false를 반환한다.")
-    @Sql("classpath:db/trim/trims-data.sql")
-    void checkIfTrimExistsFalse() {
-        //given
-        Long id = 11L;
+        @Test
+        @DisplayName("존재하지 않는 트림인 경우 false를 반환한다.")
+        @Sql("classpath:db/trim/trims-data.sql")
+        void checkIfTrimExistsFalse() {
+            //given
+            Long id = 11L;
 
-        //when
-        Boolean isExists = trimMapper.checkIfTrimExists(id);
+            //when
+            Boolean isExists = trimMapper.checkIfTrimExists(id);
 
-        //then
-        assertThat(isExists).isFalse();
+            //then
+            assertThat(isExists).isFalse();
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
@@ -31,10 +31,10 @@ class TrimMapperTest {
 
     @Nested
     @DisplayName("트림 검색 테스트")
+    @Sql("classpath:db/trim/trims-data.sql")
     class FindTest {
         @Test
         @DisplayName("존재하는 회원에 대해서, 해당하는 row를 Trim 객체에 담아 반환한다.")
-        @Sql("classpath:db/trim/trims-data.sql")
         void findById() {
             //given
             Long targetId = 1L;
@@ -50,7 +50,6 @@ class TrimMapperTest {
 
         @Test
         @DisplayName("존재하지 않는 트림에 대해서는 null을 반환한다.")
-        @Sql("classpath:db/trim/trims-data.sql")
         void findByIdWithoutResult() {
             //given
             Long targetId = Long.MAX_VALUE;
@@ -64,7 +63,6 @@ class TrimMapperTest {
 
         @Test
         @DisplayName("존재하는 회원에 대해서, 해당하는 row를 Trim 객체에 담아 반환한다.")
-        @Sql("classpath:db/trim/trims-data.sql")
         void findByCarId() {
             //given
             Long targetCarId = 1L;
@@ -82,7 +80,6 @@ class TrimMapperTest {
 
         @Test
         @DisplayName("존재하지 않는 차량에 대해서는 빈 배열을 반환한다.")
-        @Sql("classpath:db/trim/trims-data.sql")
         void findByCarIdWithoutResult() {
             //given
             Long targetCarId = Long.MAX_VALUE;
@@ -119,7 +116,7 @@ class TrimMapperTest {
 
         @Test
         @DisplayName("존재하지 않는 trim에 대해서는 빈 배열을 반환한다.")
-        @Sql("classpath:db/trim/trims-data.sql")
+        @Sql("classpath:db/trim/external-color-data.sql")
         void findExternalColorNotExists() {
             //given
             Long trimId = Long.MAX_VALUE;
@@ -152,7 +149,7 @@ class TrimMapperTest {
 
         @Test
         @DisplayName("존재하지 않는 trim에 대해서는 빈 배열을 반환한다.")
-        @Sql("classpath:db/trim/trims-data.sql")
+        @Sql("classpath:db/trim/internal-color-data.sql")
         void findInternalColorNotExists() {
             //given
             Long trimId = Long.MAX_VALUE;

--- a/backend/src/test/resources/db/image-data.sql
+++ b/backend/src/test/resources/db/image-data.sql
@@ -1,5 +1,5 @@
 INSERT INTO external_color_image (id, external_color_id, image) VALUES
-    (1, 1, 'image_url_1'),
-    (2, 1, 'image_url_2'),
-    (3, 2, 'image_url_3'),
-    (4, 3, 'image_url_4');
+    (1, 1, 'url1'),
+    (2, 1, 'url2'),
+    (3, 2, 'url3'),
+    (4, 3, 'url4');

--- a/backend/src/test/resources/db/modelType/bodytype-data.sql
+++ b/backend/src/test/resources/db/modelType/bodytype-data.sql
@@ -1,9 +1,9 @@
-INSERT INTO bodytype(id, name, description, image) VALUES
-                                                   (1, 'name1', 'description1', 'img_url1'),
-                                                   (2, 'name2', 'description2', 'img_url2'),
-                                                   (3, 'name3', 'description3', 'img_url3');
+INSERT INTO bodytype(id, name, description, image)
+VALUES (1, 'name1', 'description1', 'img_url1'),
+       (2, 'name2', 'description2', 'img_url2'),
+       (3, 'name3', 'description3', 'img_url3');
 
-INSERT INTO car_bodytype(car_id, bodytype_id, price, choice_ratio) VALUES
-                                                                       (1, 1, 10000, 0.11),
-                                                                       (1, 2, 20000, 0.21),
-                                                                       (2, 1, 30000, 0.33);
+INSERT INTO car_bodytype(car_id, bodytype_id, price, choice_ratio)
+VALUES (1, 1, 10000, 0.11),
+       (1, 2, 20000, 0.21),
+       (2, 1, 30000, 0.33);

--- a/backend/src/test/resources/db/trim/external-color-data.sql
+++ b/backend/src/test/resources/db/trim/external-color-data.sql
@@ -1,11 +1,11 @@
 INSERT INTO external_color (id, name, color_code) VALUES
     (1, 'Red', '#FF0000'),
-    (2, 'Blue', '#0000FF'),
+    (2, 'Black', '#FF0001'),
     (3, 'Green', '#00FF00');
 
 INSERT INTO trims_external_color (trim_id, external_color_id, price, choice_ratio) VALUES
-    (1, 1, 2000, 0.3),
+    (1, 1, 100, 0.5),
     (2, 1, 1500, 0.2),
-    (1, 2, 1800, 0.5),
+    (1, 2, 240, 0.2),
     (2, 2, 1600, 0.4),
     (3, 3, 2200, 0.6);

--- a/backend/src/test/resources/db/trim/trims-data.sql
+++ b/backend/src/test/resources/db/trim/trims-data.sql
@@ -13,8 +13,8 @@ VALUES
 
 INSERT INTO trims (id, car_id, name, description, price)
 VALUES
-    (1, 1, 'Trim 1', 'Basic Trim', 1500),
-    (2, 1, 'Trim 2', 'Advanced Trim', 2500),
+    (1, 1, 'Trim A', 'Description of Trim A', 50000),
+    (2, 1, 'Trim B', 'Description of Trim b', 70000),
     (3, 2, 'Trim 3', 'Standard Trim', 2000),
     (4, 2, 'Trim 4', 'Premium Trim', 3000),
     (5, 3, 'Trim 5', 'Basic Trim', 1200),


### PR DESCRIPTION
# :eyes: What is this PR?
전반적인 테스트 코드 개선/리팩토링
# :pencil: Changes
- 테스트에서 반복적으로 사용되는 entity, dto를 fixture로 분리해서 관리하도록 했습니다. 테스트 메소드들이 entity에 대한 의존성이 떨어지는 장점도 있는 것 같아서 좋은듯
- 테스트 코드 좀 추가하고, @Nested로 정리했습니다. 
- Quotation 쪽 머지 안돼서 테스트 코드 덜 건드렸습니다. QuotationService 롤백 관련 테스트 코드는 어떻게 구현해야할 지 잘 모르겠는데 행님이 하시던대로 마저 해주시면 될 것 같습니다..
- 개행 컨벤션 안지켜진 것이 있더라구요 Command shift L 생활화..!!
- OptionDto, TrimDefaultOptionDto, OptionDetailsDto 등과 패키지에서도 그렇고 entity들도 그렇고 중복된 필드를 갖는 dto, entity들이 너무 많습니다. 대공사 한 번 해야겠네요.
- 테스트 코드 아예 작성 전이었던 ModelTypeService 테스트코드는 새로 짰습니다. 다만 options는 option 패키지랑 합치고 하는 과정이 필요할 것 같아서 테스트 코드를 제가 새로 짜진 않았습니다.. 막막한 부분
- 예외처리 로직 없는 것 추가는 몇개 했는데, 리팩토링은 안했습니다. 하고 계신 예외 처리 관련 리팩토링 머지되고 나서 하는 편이 좋을 것 같아서...
- 원래 컨트롤러 단 MockMvc 테스트까지 진행하고 PR 올리려고 했는데, 머지 충돌 해결하기 빡셀 것 같아서 이정도 진행하고 올립니다. 지금 작업하시는 곳에 이거 땡겨서 충돌 해결하고, 마저 진행하는 게 좋을 것 같습니다. 깃헙 상에서 resolve하다가 대참사 생길 수도 있을 것 같아서..

## :pushpin: Related issue(s)
#221 
## :camera: Attachment(optional)
