### PR TITLE
fix: 유사 출고 견적 API 응답에 출고량 필드 추가

### DIFF
--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/QuotationService.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/QuotationService.java
@@ -104,6 +104,7 @@ public class QuotationService {
             String drivetrainName = drivetrainMapper.findById(releaseEntity.getDrivetrainId()).getName();
             String image = externalColorMapper.findImages(releaseEntity.getExternalColorId()).get(SIDE_IMAGE_INDEX).getImage();
             int price = releaseEntity.getPrice();
+            int salesCount = releaseEntity.getQuotationCount();
 
             List<OptionSummaryDto> optionSummaryDtos = extractOptionSummary(quotationRequestDto, releaseEntity);
 
@@ -115,6 +116,7 @@ public class QuotationService {
                             .build(),
                     image,
                     price,
+                    salesCount,
                     optionSummaryDtos
             ));
         }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/dto/SimilarQuotationDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/dto/SimilarQuotationDto.java
@@ -13,6 +13,7 @@ import java.util.List;
 @Builder
 public class SimilarQuotationDto {
     private ModelTypeNameDto modelType;
+    private Integer salesCount;
     private String image;
     private Integer price;
     private List<OptionSummaryDto> options;
@@ -20,11 +21,13 @@ public class SimilarQuotationDto {
     public static SimilarQuotationDto of(ModelTypeNameDto modelTypeNameDto,
                                          String image,
                                          Integer price,
+                                         Integer salesCount,
                                          List<OptionSummaryDto> options) {
         return SimilarQuotationDto.builder()
                 .modelType(modelTypeNameDto)
                 .image(image)
                 .price(price)
+                .salesCount(salesCount)
                 .options(options)
                 .build();
     }


### PR DESCRIPTION
# :eyes: What is this PR?
유사 출고 견적 API 응답에 출고량 필드 추가
# :pencil: Changes
- SimilarQuotationDto.salesCount 필드 추가

## :pushpin: Related issue(s)
closes #233 
## :camera: Attachment(optional)
![스크린샷 2023-08-21 오전 12 46 17](https://github.com/softeerbootcamp-2nd/H2-O/assets/91039622/f6927b9b-a8e0-46ad-b113-9c8f9f8eeb4b)
