### PR TITLE
Fix/#303/유사 견적 API 버그 수정

### DIFF
--- a/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/QuotationService.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/quotation/application/QuotationService.java
@@ -95,7 +95,7 @@ public class QuotationService {
             //3-2. 패키지에 포함된 해시태그 정보 가져오기
             collectHashTagsOfPackages(packageIds, hashTagCount);
 
-            //유사도 계산 후 queue에 추가
+            //3-3. 유사도 계산 후 queue에 추가
             double similarity = cosineSimilarityCalculator.calculateCosineSimilarity(requestHashTagCount, hashTagCount);
 
             if (similarity < SIMILARITY_LOWER_BOUND || similarity > SIMILARITY_UPPER_BOUND) {
@@ -114,6 +114,10 @@ public class QuotationService {
             }
 
             ReleaseEntity releaseEntity = similarityQueue.poll().getKey();
+
+            if (isOptionsSubset(quotationRequestDto, releaseEntity)) {
+                continue;
+            }
 
             String powertrainName = powertrainMapper.findById(releaseEntity.getPowertrainId()).getName();
             String bodytypeName = bodytypeMapper.findById(releaseEntity.getBodytypeId()).getName();
@@ -138,6 +142,11 @@ public class QuotationService {
         }
 
         return similarQuotationDtos;
+    }
+
+    private static boolean isOptionsSubset(QuotationRequestDto quotationRequestDto, ReleaseEntity releaseEntity) {
+        List<Long> optionIdsOfRelease = parseToLongList(releaseEntity.getOptionCombination());
+        return new HashSet<>(quotationRequestDto.getOptionIds()).containsAll(optionIdsOfRelease);
     }
 
     private List<OptionSummaryDto> extractOptionSummary(QuotationRequestDto quotationRequestDto,

--- a/backend/src/test/java/com/h2o/h2oServer/domain/option/HashTagFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/option/HashTagFixture.java
@@ -4,6 +4,7 @@ import com.h2o.h2oServer.domain.option.entity.HashTagEntity;
 import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class HashTagFixture {
 
@@ -19,5 +20,11 @@ public class HashTagFixture {
                         .name(HashTag.SPORTS)
                         .build()
         );
+    }
+
+    public static List<HashTagEntity> generateHashTagEntities(List<HashTag> hashTags) {
+        return hashTags.stream()
+                .map(hashTag -> HashTagEntity.builder().name(hashTag).build())
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/quotation/QuotationFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/quotation/QuotationFixture.java
@@ -2,6 +2,7 @@ package com.h2o.h2oServer.domain.quotation;
 
 import com.h2o.h2oServer.domain.model_type.dto.ModelTypeIdDto;
 import com.h2o.h2oServer.domain.quotation.dto.QuotationRequestDto;
+import com.h2o.h2oServer.domain.quotation.entity.ReleaseEntity;
 
 import java.util.List;
 
@@ -21,4 +22,49 @@ public class QuotationFixture {
                 .packageIds(List.of(11L))
                 .build();
     }
+
+    public static ReleaseEntity generateReleaseEntity() {
+        return ReleaseEntity.builder()
+                .packageCombination("11")
+                .optionCombination("8,9,10,11")
+                .quotationCount(32)
+                .price(10)
+                .trimId(5L)
+                .externalColorId(1L)
+                .internalColorId(3L)
+                .drivetrainId(1L)
+                .bodytypeId(1L)
+                .powertrainId(1L)
+                .build();
+    }
+
+    public static List<ReleaseEntity> generateReleaseEntityList() {
+        return List.of(
+                ReleaseEntity.builder()
+                        .packageCombination("11,12")
+                        .optionCombination("8,9,10")
+                        .quotationCount(32)
+                        .price(10)
+                        .trimId(5L)
+                        .externalColorId(1L)
+                        .internalColorId(3L)
+                        .drivetrainId(1L)
+                        .bodytypeId(1L)
+                        .powertrainId(1L)
+                        .build(),
+                ReleaseEntity.builder()
+                        .packageCombination("11")
+                        .optionCombination("8,9,11")
+                        .quotationCount(32)
+                        .price(20)
+                        .trimId(5L)
+                        .externalColorId(1L)
+                        .internalColorId(3L)
+                        .drivetrainId(1L)
+                        .bodytypeId(1L)
+                        .powertrainId(1L)
+                        .build()
+        );
+    }
+
 }

--- a/backend/src/test/java/com/h2o/h2oServer/domain/quotation/application/QuotationServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/quotation/application/QuotationServiceTest.java
@@ -2,23 +2,28 @@ package com.h2o.h2oServer.domain.quotation.application;
 
 import com.h2o.h2oServer.domain.car.exception.NoSuchCarException;
 import com.h2o.h2oServer.domain.car.mapper.CarMapper;
-import com.h2o.h2oServer.domain.model_type.dto.ModelTypeIdDto;
+import com.h2o.h2oServer.domain.model_type.BodytypeFixture;
+import com.h2o.h2oServer.domain.model_type.DrivetrainFixture;
+import com.h2o.h2oServer.domain.model_type.PowertrainFixture;
 import com.h2o.h2oServer.domain.model_type.exception.NoSuchBodyTypeException;
 import com.h2o.h2oServer.domain.model_type.exception.NoSuchDriveTrainException;
 import com.h2o.h2oServer.domain.model_type.exception.NoSuchPowertrainException;
 import com.h2o.h2oServer.domain.model_type.mapper.BodytypeMapper;
 import com.h2o.h2oServer.domain.model_type.mapper.DrivetrainMapper;
 import com.h2o.h2oServer.domain.model_type.mapper.PowertrainMapper;
+import com.h2o.h2oServer.domain.option.HashTagFixture;
+import com.h2o.h2oServer.domain.option.OptionFixture;
+import com.h2o.h2oServer.domain.option.entity.enums.HashTag;
 import com.h2o.h2oServer.domain.option.exception.NoSuchOptionException;
 import com.h2o.h2oServer.domain.option.mapper.OptionMapper;
 import com.h2o.h2oServer.domain.optionPackage.exception.NoSuchPackageException;
 import com.h2o.h2oServer.domain.optionPackage.mapper.PackageMapper;
-import com.h2o.h2oServer.domain.quotation.dto.QuotationCountDto;
-import com.h2o.h2oServer.domain.quotation.dto.QuotationDto;
-import com.h2o.h2oServer.domain.quotation.dto.QuotationRequestDto;
-import com.h2o.h2oServer.domain.quotation.dto.QuotationResponseDto;
+import com.h2o.h2oServer.domain.quotation.dto.*;
+import com.h2o.h2oServer.domain.quotation.entity.ReleaseEntity;
 import com.h2o.h2oServer.domain.quotation.mapper.QuotationMapper;
 import com.h2o.h2oServer.domain.trim.Exception.NoSuchTrimException;
+import com.h2o.h2oServer.domain.trim.ExternalColorFixture;
+import com.h2o.h2oServer.domain.trim.ImageFixture;
 import com.h2o.h2oServer.domain.trim.mapper.ExternalColorMapper;
 import com.h2o.h2oServer.domain.trim.mapper.TrimMapper;
 import org.assertj.core.api.SoftAssertions;
@@ -28,10 +33,14 @@ import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.util.List;
+import java.util.Optional;
 
+import static com.h2o.h2oServer.domain.option.HashTagFixture.*;
+import static com.h2o.h2oServer.domain.quotation.QuotationFixture.*;
 import static com.h2o.h2oServer.domain.quotation.QuotationFixture.generateQuotationRequestDto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 @MybatisTest
@@ -175,6 +184,169 @@ class QuotationServiceTest {
             //then
             assertThatThrownBy(() -> quotationService.saveQuotation(generateQuotationRequestDto()))
                     .isInstanceOf(NoSuchPackageException.class);
+        }
+
+    }
+    
+    @Nested
+    @DisplayName("유사 견적 추천 기능 테스트")
+    class findSimilarQuotationTest {
+
+        @Test
+        @DisplayName("유사 견적을 추천한다.")
+        void findSimilarQuotation() {
+            //given
+            QuotationRequestDto quotationRequestDto = generateQuotationRequestDto();
+            when(quotationMapper.findReleaseQuotationWithVolume(quotationRequestDto.getTrimId()))
+                    .thenReturn(generateReleaseEntityList());
+            when(packageMapper.findHashTag(11L))
+                    .thenReturn(generateHashTagEntities());
+            when(packageMapper.findHashTag(12L))
+                    .thenReturn(generateHashTagEntities(List.of(HashTag.LEISURE, HashTag.LEISURE)));
+            when(optionMapper.findHashTag(8L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.COMMUTE, HashTag.COMFORTABLE)));
+            when(optionMapper.findHashTag(9L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.MALE, HashTag.CHILD_COMMUTE, HashTag.STYLE)));
+            when(optionMapper.findHashTag(10L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.STYLE, HashTag.STYLE, HashTag.COUPLE)));
+            when(optionMapper.findHashTag(11L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.COMMUTE, HashTag.COMFORTABLE)));
+            when(powertrainMapper.findById(1L)).thenReturn(PowertrainFixture.generatePowertrainEntity());
+            when(bodytypeMapper.findById(1L)).thenReturn(BodytypeFixture.generateBodytypeEntity());
+            when(drivetrainMapper.findById(1L)).thenReturn(DrivetrainFixture.generateDrivetrainEntity());
+            when(externalColorMapper.findImages(1L)).thenReturn(ImageFixture.generateExternalImageEntityList());
+            when(optionMapper.findOptionDetails(anyLong(), anyLong())).thenReturn(Optional.of(OptionFixture.generateOptionDetailsEntity()));
+            when(cosineSimilarityCalculator.calculateCosineSimilarity(anyMap(), anyMap())).thenReturn(0.7);
+
+            //when
+            List<SimilarQuotationDto> actualSimilarQuotationDto = quotationService.findSimilarQuotations(quotationRequestDto);
+
+            //then
+            softly.assertThat(actualSimilarQuotationDto.size()).isEqualTo(1);
+            SimilarQuotationDto similarQuotationDto = actualSimilarQuotationDto.get(0);
+            softly.assertThat(similarQuotationDto.getImage()).isEqualTo("url1");
+            softly.assertThat(similarQuotationDto.getPrice()).isEqualTo(20);
+            softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("유사도가 < 20%, > 90%인 경우는 추천하지 않는다.")
+        void withSimilarityOutOfBound() {
+            //given
+            QuotationRequestDto quotationRequestDto = generateQuotationRequestDto();
+
+            when(quotationMapper.findReleaseQuotationWithVolume(quotationRequestDto.getTrimId()))
+                    .thenReturn(List.of(
+                            ReleaseEntity.builder()
+                                    .packageCombination("11,12")
+                                    .optionCombination("8,9,10,12")
+                                    .quotationCount(32)
+                                    .price(10)
+                                    .trimId(5L)
+                                    .externalColorId(1L)
+                                    .internalColorId(3L)
+                                    .drivetrainId(1L)
+                                    .bodytypeId(1L)
+                                    .powertrainId(1L)
+                                    .build(),
+                            ReleaseEntity.builder()
+                                    .packageCombination("11")
+                                    .optionCombination("8,9,11")
+                                    .quotationCount(32)
+                                    .price(20)
+                                    .trimId(5L)
+                                    .externalColorId(1L)
+                                    .internalColorId(3L)
+                                    .drivetrainId(1L)
+                                    .bodytypeId(1L)
+                                    .powertrainId(1L)
+                                    .build()
+                    ));
+            when(packageMapper.findHashTag(11L))
+                    .thenReturn(generateHashTagEntities());
+            when(packageMapper.findHashTag(12L))
+                    .thenReturn(generateHashTagEntities(List.of(HashTag.LEISURE, HashTag.LEISURE)));
+            when(optionMapper.findHashTag(8L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.COMMUTE, HashTag.COMFORTABLE)));
+            when(optionMapper.findHashTag(9L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.MALE, HashTag.CHILD_COMMUTE, HashTag.STYLE)));
+            when(optionMapper.findHashTag(10L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.STYLE, HashTag.STYLE, HashTag.COUPLE)));
+            when(optionMapper.findHashTag(11L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.COMMUTE, HashTag.COMFORTABLE)));
+            when(optionMapper.findHashTag(12L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.COMMUTE, HashTag.COMFORTABLE)));
+            when(powertrainMapper.findById(1L)).thenReturn(PowertrainFixture.generatePowertrainEntity());
+            when(bodytypeMapper.findById(1L)).thenReturn(BodytypeFixture.generateBodytypeEntity());
+            when(drivetrainMapper.findById(1L)).thenReturn(DrivetrainFixture.generateDrivetrainEntity());
+            when(externalColorMapper.findImages(1L)).thenReturn(ImageFixture.generateExternalImageEntityList());
+            when(optionMapper.findOptionDetails(anyLong(), anyLong())).thenReturn(Optional.of(OptionFixture.generateOptionDetailsEntity()));
+            when(cosineSimilarityCalculator.calculateCosineSimilarity(anyMap(), anyMap())).thenReturn(0.1);
+
+            //when
+            List<SimilarQuotationDto> actualSimilarQuotationDto = quotationService.findSimilarQuotations(quotationRequestDto);
+
+            //then
+            assertThat(actualSimilarQuotationDto.size()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("요청 견적보다 추가 견적이 없는 경우 추천하지 않는다.")
+        void withoutAdditionalOptions() {
+            //given
+            QuotationRequestDto quotationRequestDto = generateQuotationRequestDto();
+
+            when(quotationMapper.findReleaseQuotationWithVolume(quotationRequestDto.getTrimId()))
+                    .thenReturn(List.of(
+                            ReleaseEntity.builder()
+                                    .packageCombination("11,12")
+                                    .optionCombination("8,9")
+                                    .quotationCount(32)
+                                    .price(10)
+                                    .trimId(5L)
+                                    .externalColorId(1L)
+                                    .internalColorId(3L)
+                                    .drivetrainId(1L)
+                                    .bodytypeId(1L)
+                                    .powertrainId(1L)
+                                    .build(),
+                            ReleaseEntity.builder()
+                                    .packageCombination("11")
+                                    .optionCombination("8,10")
+                                    .quotationCount(32)
+                                    .price(20)
+                                    .trimId(5L)
+                                    .externalColorId(1L)
+                                    .internalColorId(3L)
+                                    .drivetrainId(1L)
+                                    .bodytypeId(1L)
+                                    .powertrainId(1L)
+                                    .build()
+                    ));
+            when(packageMapper.findHashTag(11L))
+                    .thenReturn(generateHashTagEntities());
+            when(packageMapper.findHashTag(12L))
+                    .thenReturn(generateHashTagEntities(List.of(HashTag.LEISURE, HashTag.LEISURE)));
+            when(optionMapper.findHashTag(8L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.COMMUTE, HashTag.COMFORTABLE)));
+            when(optionMapper.findHashTag(9L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.MALE, HashTag.CHILD_COMMUTE, HashTag.STYLE)));
+            when(optionMapper.findHashTag(10L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.STYLE, HashTag.STYLE, HashTag.COUPLE)));
+            when(optionMapper.findHashTag(11L))
+                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.COMMUTE, HashTag.COMFORTABLE)));
+            when(powertrainMapper.findById(1L)).thenReturn(PowertrainFixture.generatePowertrainEntity());
+            when(bodytypeMapper.findById(1L)).thenReturn(BodytypeFixture.generateBodytypeEntity());
+            when(drivetrainMapper.findById(1L)).thenReturn(DrivetrainFixture.generateDrivetrainEntity());
+            when(externalColorMapper.findImages(1L)).thenReturn(ImageFixture.generateExternalImageEntityList());
+            when(optionMapper.findOptionDetails(anyLong(), anyLong())).thenReturn(Optional.of(OptionFixture.generateOptionDetailsEntity()));
+            when(cosineSimilarityCalculator.calculateCosineSimilarity(anyMap(), anyMap())).thenReturn(0.7);
+
+            //when
+            List<SimilarQuotationDto> actualSimilarQuotationDto = quotationService.findSimilarQuotations(quotationRequestDto);
+
+            //then
+            assertThat(actualSimilarQuotationDto.size()).isEqualTo(0);
         }
     }
 

--- a/backend/src/test/java/com/h2o/h2oServer/domain/quotation/application/QuotationServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/quotation/application/QuotationServiceTest.java
@@ -192,11 +192,12 @@ class QuotationServiceTest {
     @DisplayName("유사 견적 추천 기능 테스트")
     class findSimilarQuotationTest {
 
-        @Test
-        @DisplayName("유사 견적을 추천한다.")
-        void findSimilarQuotation() {
-            //given
-            QuotationRequestDto quotationRequestDto = generateQuotationRequestDto();
+        private QuotationRequestDto quotationRequestDto;
+
+        @BeforeEach
+        void setup() {
+            quotationRequestDto = generateQuotationRequestDto();
+
             when(quotationMapper.findReleaseQuotationWithVolume(quotationRequestDto.getTrimId()))
                     .thenReturn(generateReleaseEntityList());
             when(packageMapper.findHashTag(11L))
@@ -216,6 +217,12 @@ class QuotationServiceTest {
             when(drivetrainMapper.findById(1L)).thenReturn(DrivetrainFixture.generateDrivetrainEntity());
             when(externalColorMapper.findImages(1L)).thenReturn(ImageFixture.generateExternalImageEntityList());
             when(optionMapper.findOptionDetails(anyLong(), anyLong())).thenReturn(Optional.of(OptionFixture.generateOptionDetailsEntity()));
+        }
+
+        @Test
+        @DisplayName("유사 견적을 추천한다.")
+        void findSimilarQuotation() {
+            //given
             when(cosineSimilarityCalculator.calculateCosineSimilarity(anyMap(), anyMap())).thenReturn(0.7);
 
             //when
@@ -233,7 +240,6 @@ class QuotationServiceTest {
         @DisplayName("유사도가 < 20%, > 90%인 경우는 추천하지 않는다.")
         void withSimilarityOutOfBound() {
             //given
-            QuotationRequestDto quotationRequestDto = generateQuotationRequestDto();
 
             when(quotationMapper.findReleaseQuotationWithVolume(quotationRequestDto.getTrimId()))
                     .thenReturn(List.of(
@@ -262,25 +268,8 @@ class QuotationServiceTest {
                                     .powertrainId(1L)
                                     .build()
                     ));
-            when(packageMapper.findHashTag(11L))
-                    .thenReturn(generateHashTagEntities());
-            when(packageMapper.findHashTag(12L))
-                    .thenReturn(generateHashTagEntities(List.of(HashTag.LEISURE, HashTag.LEISURE)));
-            when(optionMapper.findHashTag(8L))
-                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.COMMUTE, HashTag.COMFORTABLE)));
-            when(optionMapper.findHashTag(9L))
-                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.MALE, HashTag.CHILD_COMMUTE, HashTag.STYLE)));
-            when(optionMapper.findHashTag(10L))
-                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.STYLE, HashTag.STYLE, HashTag.COUPLE)));
-            when(optionMapper.findHashTag(11L))
-                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.COMMUTE, HashTag.COMFORTABLE)));
             when(optionMapper.findHashTag(12L))
                     .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.COMMUTE, HashTag.COMFORTABLE)));
-            when(powertrainMapper.findById(1L)).thenReturn(PowertrainFixture.generatePowertrainEntity());
-            when(bodytypeMapper.findById(1L)).thenReturn(BodytypeFixture.generateBodytypeEntity());
-            when(drivetrainMapper.findById(1L)).thenReturn(DrivetrainFixture.generateDrivetrainEntity());
-            when(externalColorMapper.findImages(1L)).thenReturn(ImageFixture.generateExternalImageEntityList());
-            when(optionMapper.findOptionDetails(anyLong(), anyLong())).thenReturn(Optional.of(OptionFixture.generateOptionDetailsEntity()));
             when(cosineSimilarityCalculator.calculateCosineSimilarity(anyMap(), anyMap())).thenReturn(0.1);
 
             //when
@@ -294,8 +283,6 @@ class QuotationServiceTest {
         @DisplayName("요청 견적보다 추가 견적이 없는 경우 추천하지 않는다.")
         void withoutAdditionalOptions() {
             //given
-            QuotationRequestDto quotationRequestDto = generateQuotationRequestDto();
-
             when(quotationMapper.findReleaseQuotationWithVolume(quotationRequestDto.getTrimId()))
                     .thenReturn(List.of(
                             ReleaseEntity.builder()
@@ -323,23 +310,6 @@ class QuotationServiceTest {
                                     .powertrainId(1L)
                                     .build()
                     ));
-            when(packageMapper.findHashTag(11L))
-                    .thenReturn(generateHashTagEntities());
-            when(packageMapper.findHashTag(12L))
-                    .thenReturn(generateHashTagEntities(List.of(HashTag.LEISURE, HashTag.LEISURE)));
-            when(optionMapper.findHashTag(8L))
-                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.COMMUTE, HashTag.COMFORTABLE)));
-            when(optionMapper.findHashTag(9L))
-                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.MALE, HashTag.CHILD_COMMUTE, HashTag.STYLE)));
-            when(optionMapper.findHashTag(10L))
-                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.STYLE, HashTag.STYLE, HashTag.COUPLE)));
-            when(optionMapper.findHashTag(11L))
-                    .thenReturn(HashTagFixture.generateHashTagEntities(List.of(HashTag.COMMUTE, HashTag.COMFORTABLE)));
-            when(powertrainMapper.findById(1L)).thenReturn(PowertrainFixture.generatePowertrainEntity());
-            when(bodytypeMapper.findById(1L)).thenReturn(BodytypeFixture.generateBodytypeEntity());
-            when(drivetrainMapper.findById(1L)).thenReturn(DrivetrainFixture.generateDrivetrainEntity());
-            when(externalColorMapper.findImages(1L)).thenReturn(ImageFixture.generateExternalImageEntityList());
-            when(optionMapper.findOptionDetails(anyLong(), anyLong())).thenReturn(Optional.of(OptionFixture.generateOptionDetailsEntity()));
             when(cosineSimilarityCalculator.calculateCosineSimilarity(anyMap(), anyMap())).thenReturn(0.7);
 
             //when

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/ImageFixture.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/ImageFixture.java
@@ -2,6 +2,8 @@ package com.h2o.h2oServer.domain.trim;
 
 import com.h2o.h2oServer.domain.trim.entity.ImageEntity;
 
+import java.awt.*;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ImageFixture {
@@ -16,5 +18,18 @@ public class ImageFixture {
                         .id(2L)
                         .build()
         );
+    }
+
+    public static List<ImageEntity> generateExternalImageEntityList() {
+        List<ImageEntity> result = new ArrayList<>();
+
+        for (int i = 0; i < 60; i++) {
+            result.add(ImageEntity.builder()
+                    .image("url1")
+                    .id(1L)
+                    .build());
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
# :eyes: What is this PR?
유사견적 API가 "본인의 견적에 추가적인 옵션을 갖지 않는 유사 견적"을 추천해주는 버그 수정
# :pencil: Changes
- 유사 견적의 옵션이 요청 견적의 subset인지 확인하는 로직 추가
-  유사 견적 계산 로직 테스트 코드 구현

테스트 커버리지 많이 높아져서 기분이 좋습니다. options랑 option 패키지 합치는 리팩토링 후에 요 부분 테스트코드도 마무리해야할 것 같아요

## :pushpin: Related issue(s)
closes #303 
