### PR TITLE
Fix/#314/차량 모델타입 성능 API 버그 수정

### DIFF
--- a/backend/src/main/java/com/h2o/h2oServer/domain/model_type/dto/TechnicalSpecDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/model_type/dto/TechnicalSpecDto.java
@@ -2,18 +2,17 @@ package com.h2o.h2oServer.domain.model_type.dto;
 
 import com.h2o.h2oServer.domain.model_type.Entity.TechnicalSpecEntity;
 import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @ApiModel(value = "차량 성능 정보 조회 응답")
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class TechnicalSpecDto {
     private Integer displacement;
     private Float fuelEfficiency;
-
-    private TechnicalSpecDto(Integer displacement, Float fuelEfficiency) {
-        this.displacement = displacement;
-        this.fuelEfficiency = fuelEfficiency;
-    }
 
     public static TechnicalSpecDto of(TechnicalSpecEntity technicalSpecEntity) {
         return new TechnicalSpecDto(


### PR DESCRIPTION
# :eyes: What is this PR?
모델 타입 성능 API가 두 번째 요청부터 응답하지 않는 버그 수정
# :pencil: Changes
- TechnicalSpecDto에 생성자 추가 -> redis에 캐싱된 정보를 가져올 때 Jackson에 의한 역직렬화가 동작하지 않는 버그 수정 

## :pushpin: Related issue(s)
closes #314 