### PR TITLE
fix: 옵션 페이지 수정

### DIFF
--- a/frontend/src/components/option/constants/index.ts
+++ b/frontend/src/components/option/constants/index.ts
@@ -16,6 +16,7 @@ export const HASHTAG_LIST = [
 ];
 
 export const EXTRA_OPTION_CATEGORY_LIST = ['전체', '상세품목', '액세서리', '휠'];
+export const EXTRA_OPTION_CATEGORY_LIST_FILTER = ['전체', '상세품목', '악세사리', '휠'];
 
 export const DEFAULT_CATEGORY_OPTION_LIST = [
   '전체',

--- a/frontend/src/components/option/hooks/useFilter.ts
+++ b/frontend/src/components/option/hooks/useFilter.ts
@@ -75,9 +75,9 @@ function reducer(state: State, action: Action): State {
         defaultOptionEntireList: action.payload.defaultOptionList,
       };
     case 'CLICK_EXTRA_OPTION':
-      return { ...state, isExtraOption: true };
+      return { ...state, isExtraOption: true, input: '', extraOptionList: state.extraOptionEntireList };
     case 'CLICK_DEFAULT_OPTION':
-      return { ...state, isExtraOption: false };
+      return { ...state, isExtraOption: false, input: '', defaultOptionList: state.defaultOptionEntireList };
     case 'CLICK_EXTRA_CATEGORY':
       return {
         ...state,

--- a/frontend/src/components/option/hooks/useFilter.ts
+++ b/frontend/src/components/option/hooks/useFilter.ts
@@ -1,6 +1,10 @@
 import { useCallback, useReducer } from 'react';
 import type { DefaultOptionResponse, ExtraOptionResponse } from '@/types/response';
-import { DEFAULT_CATEGORY_OPTION_LIST, EXTRA_OPTION_CATEGORY_LIST, HASHTAG_LIST } from '@/components/option/constants';
+import {
+  DEFAULT_CATEGORY_OPTION_LIST,
+  EXTRA_OPTION_CATEGORY_LIST_FILTER,
+  HASHTAG_LIST,
+} from '@/components/option/constants';
 
 type Action =
   | {
@@ -37,7 +41,8 @@ interface DefaultFilterProps {
 }
 
 const filterExtraOption = ({ input, entireList }: ExtraFilterProps) => {
-  if (EXTRA_OPTION_CATEGORY_LIST.includes(input)) return entireList.filter((option) => option.category === input);
+  if (EXTRA_OPTION_CATEGORY_LIST_FILTER.includes(input))
+    return entireList.filter((option) => option.category === input);
   if (HASHTAG_LIST.includes(input)) return entireList.filter((option) => option.hashTags.includes(input));
   return entireList.filter((option) => option.name.includes(input));
 };
@@ -75,7 +80,9 @@ function reducer(state: State, action: Action): State {
         ...state,
         extraCategoryIdx: action.payload,
         extraOptionList: action.payload
-          ? state.extraOptionEntireList.filter((opt) => opt.category === EXTRA_OPTION_CATEGORY_LIST[action.payload])
+          ? state.extraOptionEntireList.filter(
+              (opt) => opt.category === EXTRA_OPTION_CATEGORY_LIST_FILTER[action.payload],
+            )
           : state.extraOptionEntireList,
       };
     case 'CLICK_DEFAULT_CATEGORY':

--- a/frontend/src/components/option/hooks/useFilter.ts
+++ b/frontend/src/components/option/hooks/useFilter.ts
@@ -2,6 +2,7 @@ import { useCallback, useReducer } from 'react';
 import type { DefaultOptionResponse, ExtraOptionResponse } from '@/types/response';
 import {
   DEFAULT_CATEGORY_OPTION_LIST,
+  EXTRA_OPTION_CATEGORY_LIST,
   EXTRA_OPTION_CATEGORY_LIST_FILTER,
   HASHTAG_LIST,
 } from '@/components/option/constants';
@@ -41,8 +42,10 @@ interface DefaultFilterProps {
 }
 
 const filterExtraOption = ({ input, entireList }: ExtraFilterProps) => {
-  if (EXTRA_OPTION_CATEGORY_LIST_FILTER.includes(input))
-    return entireList.filter((option) => option.category === input);
+  if (EXTRA_OPTION_CATEGORY_LIST.includes(input))
+    return entireList.filter((option) =>
+      option.category === '악세사리' ? input === '액세서리' : option.category === input,
+    );
   if (HASHTAG_LIST.includes(input)) return entireList.filter((option) => option.hashTags.includes(input));
   return entireList.filter((option) => option.name.includes(input));
 };

--- a/frontend/src/components/option/utils/SearchBar.tsx
+++ b/frontend/src/components/option/utils/SearchBar.tsx
@@ -49,7 +49,7 @@ function SearchBar({ isExtraOption = false, input, optionList, filterList }: Pro
   };
 
   useEffect(() => {
-    input === '' ? setDropDownList([]) : setDropDownList(optionList);
+    !input ? setDropDownList([]) : setDropDownList(optionList);
   }, [optionList]);
 
   return (

--- a/frontend/src/components/option/utils/SearchBar.tsx
+++ b/frontend/src/components/option/utils/SearchBar.tsx
@@ -12,14 +12,14 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 }
 
 function SearchBar({ isExtraOption = false, input, optionList, filterList }: Props) {
-  const [dropDownList, setDropDownList] = useState<ExtraOptionResponse[] | DefaultOptionResponse[]>(optionList);
+  const [dropDownList, setDropDownList] = useState<ExtraOptionResponse[] | DefaultOptionResponse[]>([]);
   const [isActive, setIsActive] = useState(false);
   const [itemIdx, setItemIdx] = useState(-1);
 
   const handleChangeInput: ChangeEventHandler<HTMLInputElement> = (e) => {
     filterList(e.target.value);
     if (e.target.value === '') setIsActive(false);
-    else dropDownList.length && setIsActive(true);
+    else optionList.length && setIsActive(true);
   };
 
   const handleKeyBoard: KeyboardEventHandler<HTMLInputElement> = (e) => {
@@ -49,12 +49,8 @@ function SearchBar({ isExtraOption = false, input, optionList, filterList }: Pro
   };
 
   useEffect(() => {
-    setDropDownList(optionList);
+    input === '' ? setDropDownList([]) : setDropDownList(optionList);
   }, [optionList]);
-
-  useEffect(() => {
-    handleSearchItem('');
-  }, [isExtraOption]);
 
   return (
     <Flex flexDirection='column' position='relative'>

--- a/frontend/src/pages/OptionPage/OptionPage.tsx
+++ b/frontend/src/pages/OptionPage/OptionPage.tsx
@@ -102,16 +102,18 @@ function OptionPage() {
                 기본옵션
               </Tab>
             </Flex>
-            {isExtraOption ? (
-              <SearchBar
-                isExtraOption={true}
-                optionList={extraOptionList}
-                input={input}
-                filterList={handleChangeInput}
-              />
-            ) : (
-              <SearchBar optionList={defaultOptionList} input={input} filterList={handleChangeInput} />
-            )}
+            {isExtraOption
+              ? extraCategoryIdx === 0 && (
+                  <SearchBar
+                    isExtraOption={true}
+                    optionList={extraOptionList}
+                    input={input}
+                    filterList={handleChangeInput}
+                  />
+                )
+              : defaultCategoryIdx === 0 && (
+                  <SearchBar optionList={defaultOptionList} input={input} filterList={handleChangeInput} />
+                )}
           </Flex>
           <Flex gap={8}>
             {isExtraOption


### PR DESCRIPTION
# :eyes: What is this PR?
- FE 옵션 페이지 수정

# :pencil: Changes
- "액세서리" 카테고리 버튼 클릭 가능
- "액세서리" 검색창에 검색 가능
- QA 통해서 검색 기능은 전체에서만 가능한 것을 고려해달라 했기 때문에 검색창은 전체 카테고리에서만 존재하게 만들었음
  ** 탭 이동은 사용자가 원하지 않은 이동일 수도 있으니까 전체 카테고리 탭 이외는 검색 기능을 아예 방지함
  ** 전체에서만 검색 기능이 가능한 이유는 기획서에 카테고리 검색이 가능한데, 카테고리 버튼을 누르고 카테고리 검색을 한다는 것은 이상하다고 느꼈습니다. 따라서 검색 기능은 전체에서 하는 거라고 해석함.
- 검색을 처음 시작할 경우 전체 리스트가 나오는데 수정함

## :pushpin: Related issue(s)
- #318 

## :camera: Attachment(optional)

### before

https://github.com/softeerbootcamp-2nd/H2-O/assets/96720326/45441ef2-8aed-4f75-8ed5-7d41fd4fc73d


### after


https://github.com/softeerbootcamp-2nd/H2-O/assets/96720326/539340a7-28f6-48a9-acec-4eb799bfc585

